### PR TITLE
Add initial API endpoint and significant refactoring

### DIFF
--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation "io.ktor:ktor-server-netty:$ktorVersion"
     implementation "io.ktor:ktor-auth:$ktorVersion"
     implementation "io.ktor:ktor-auth-jwt:$ktorVersion"
+    implementation "io.ktor:ktor-jackson:$ktorVersion"
 
     implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"

--- a/bot/config/epilink_config.yaml
+++ b/bot/config/epilink_config.yaml
@@ -4,15 +4,17 @@
 # The name of the server. You can customize this if you want to.
 name: My EpiLink Instance
 
-# The port that should be used for the server.
-serverPort: 9090
+# HTTP server configuration
+server:
+  # The port that should be used for the server.
+  port: 9090
+  # Time in milliseconds before a session expires. Here, one month
+  sessionDuration: 2592000000
+  # The URL of the front-end, WITH a trailing slash /, or null if the URL is unknown or the frontend is bootstrapped
+  frontendUrl: ~
 
 # Name and location of the EpiLink SQLite database
 db: epilink.db
-
-
-# Time in milliseconds before a session expires. Here, one month
-sessionDuration: 2592000000
 
 # The tokens to use when connecting
 # Note that providing them in the configuration file is optional. If you do not define them here, you can pass them as

--- a/bot/src/org/epilink/bot/ApiResponse.kt
+++ b/bot/src/org/epilink/bot/ApiResponse.kt
@@ -1,0 +1,27 @@
+package org.epilink.bot
+
+/**
+ * Something that can be sent by the EpiLink API. Anything served from
+ * /api/ is almost always using this class in serialized JSON form.
+ *
+ * @param T The type of the data, or `Nothing?` if no data is expected.
+ */
+data class ApiResponse<T>(
+    /**
+     * True if the operation was successful, false if there was an error.
+     *
+     * If the operation was successful and data is expected, data will be equal
+     * to something other than null.
+     *
+     * If the operation was unsuccessful, the message should be non-null.
+     */
+    val success: Boolean,
+    /**
+     * An optional message explaining the success or failure.
+     */
+    val message: String? = null,
+    /**
+     * Data attached to this response
+     */
+    val data: T?
+)

--- a/bot/src/org/epilink/bot/LinkConfig.kt
+++ b/bot/src/org/epilink/bot/LinkConfig.kt
@@ -8,9 +8,14 @@ import java.nio.file.Path
 
 data class LinkConfiguration(
     val name: String,
-    val serverPort: Int,
+    val server: LinkWebServerConfiguration,
     val db: String,
-    val tokens: LinkTokens,
+    val tokens: LinkTokens
+)
+
+data class LinkWebServerConfiguration(
+    val port: Int,
+    val frontendUrl: String?,
     val sessionDuration: Long
 )
 

--- a/bot/src/org/epilink/bot/LinkServerApi.kt
+++ b/bot/src/org/epilink/bot/LinkServerApi.kt
@@ -1,0 +1,143 @@
+package org.epilink.bot
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.JWTVerifier
+import com.auth0.jwt.algorithms.Algorithm
+import io.ktor.auth.Authentication
+import io.ktor.auth.jwt.JWTPrincipal
+import io.ktor.features.ContentNegotiation
+import io.ktor.server.engine.ApplicationEngine
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import java.util.*
+import io.ktor.application.call
+import io.ktor.application.install
+import io.ktor.auth.authenticate
+import io.ktor.auth.authentication
+import io.ktor.auth.jwt.jwt
+import io.ktor.http.HttpStatusCode
+import io.ktor.jackson.jackson
+import io.ktor.response.respond
+import io.ktor.response.respondRedirect
+import io.ktor.response.respondText
+import io.ktor.routing.Route
+import io.ktor.routing.get
+import io.ktor.routing.route
+import io.ktor.routing.routing
+
+private const val JWT_USER_AUDIENCE = "user"
+
+/**
+ * This class represents the Ktor server.
+ */
+class LinkServerApi(
+    /**
+     * The environment this server lives in
+     */
+    private val env: LinkServerEnvironment,
+    /**
+     * Configuration specifically or the web server
+     */
+    private val wsCfg: LinkWebServerConfiguration,
+    /**
+     * The secret to use. Separate from wsCfg because this is a secret token.
+     */
+    jwtSecret: String?
+) {
+    /**
+     * The actual Ktor application instance
+     */
+    private var server: ApplicationEngine = ktorServer(wsCfg.port)
+
+    /**
+     * The algorithm to use for JWT related duties
+     */
+    private val jwtAlgorithm = Algorithm.HMAC256(jwtSecret)
+
+    /**
+     * Start the server. If wait is true, this function will block until the
+     * server stops.
+     */
+    fun startServer(wait: Boolean) {
+        server.start(wait)
+    }
+
+    /**
+     * Create the server, and configure it
+     */
+    private fun ktorServer(port: Int) =
+        embeddedServer(Netty, port) {
+            install(Authentication) {
+                jwt {
+                    realm = env.name
+                    verifier(makeJwtVerifier(env.name, JWT_USER_AUDIENCE))
+                    validate { JWTPrincipal(it.payload) }
+                }
+            }
+            /*
+             * Used for automatically converting stuff to JSON when calling
+             * "respond" with generic objects.
+             */
+            install(ContentNegotiation) {
+                jackson {}
+            }
+
+            routing {
+                /*
+                 * Main endpoint. If the user directly tries to connect to the
+                 * back-end, redirect them to the front-end (or 404 if the url
+                 * is unknown).
+                 *
+                 * Once the opportunity will be given to bootstrap the front-end
+                 * in the back-end, this could also just serve the front-end.
+                 */
+                get("/") {
+                    val url = wsCfg.frontendUrl
+                    if (url == null) {
+                        // 404
+                        call.respond(HttpStatusCode.NotFound)
+                    } else {
+                        // Redirect to frontend
+                        call.respondRedirect(url, permanent = true)
+                    }
+                }
+                /*
+                 * Main API endpoint
+                 */
+                route("/api/v1") {
+                    epilinkApiV1()
+                }
+            }
+        }
+
+
+    private fun makeJwtVerifier(issuer: String, audience: String): JWTVerifier =
+        JWT.require(jwtAlgorithm)
+            .withAudience(audience)
+            .withIssuer(issuer)
+            .build()
+
+    private fun makeJwt(subject: String) =
+        JWT.create().apply {
+            withSubject(subject)
+            withIssuedAt(Date())
+            withExpiresAt(Date(System.currentTimeMillis() + wsCfg.sessionDuration))
+            withAudience(JWT_USER_AUDIENCE)
+            withIssuer(env.name)
+            sign(jwtAlgorithm)
+        }
+
+    /**
+     * Defines the API endpoints. Served under /api/v1
+     *
+     * Anything responded in here SHOULD use [ApiResponse] in JSON form.
+     */
+    private fun Route.epilinkApiV1() {
+        /*
+         * Just a hello world for now, answering in JSON
+         */
+        get("hello") {
+            call.respond(ApiResponse(true, "Hello World", null))
+        }
+    }
+}

--- a/bot/src/org/epilink/bot/LinkServerEnvironment.kt
+++ b/bot/src/org/epilink/bot/LinkServerEnvironment.kt
@@ -1,90 +1,22 @@
 package org.epilink.bot
 
-import java.util.*
-
-import com.auth0.jwt.JWT
-import com.auth0.jwt.JWTVerifier
-import com.auth0.jwt.algorithms.Algorithm
-
-import io.ktor.application.call
-import io.ktor.application.install
-import io.ktor.auth.Authentication
-import io.ktor.auth.authenticate
-import io.ktor.auth.authentication
-import io.ktor.auth.jwt.JWTPrincipal
-import io.ktor.auth.jwt.jwt
-import io.ktor.response.respond
-import io.ktor.response.respondText
-import io.ktor.routing.get
-import io.ktor.routing.routing
-import io.ktor.server.engine.ApplicationEngine
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
-
-private const val JWT_USER_AUDIENCE = "user"
-
 /**
  * This class is responsible for holding configuration information and
- * references to things like the Discord client, the Database environment, etc.
+ * references to things like the Discord client, the Database environment, the
+ * server, etc.
  */
 class LinkServerEnvironment(
     private val cfg: LinkConfiguration
 ) {
-    private var database: LinkServerDatabase = LinkServerDatabase(cfg)
-    private val jwtAlgorithm = Algorithm.HMAC256(cfg.tokens.jwtSecret)
-    private var server: ApplicationEngine = ktorServer()
+    var database: LinkServerDatabase = LinkServerDatabase(cfg)
+        private set
+    private var api: LinkServerApi =
+        LinkServerApi(this, cfg.server, cfg.tokens.jwtSecret)
 
     val name: String
         get() = cfg.name
 
     fun start() {
-        server.start(wait = true)
+        api.startServer(wait = true)
     }
-
-    fun ktorServer() =
-        embeddedServer(Netty, cfg.serverPort) {
-            install(Authentication) {
-                jwt {
-                    realm = cfg.name
-                    verifier(makeJwtVerifier(cfg.name, JWT_USER_AUDIENCE))
-                    validate { JWTPrincipal(it.payload) }
-                }
-            }
-
-            routing {
-                get("/") {
-                    val usersCount = database.countUsers()
-                    call.respondText("EpiLink back-end server, welcome! $usersCount registered users.")
-                }
-
-                authenticate() {
-                    get("/admin") {
-                        val principal = call.authentication.principal<JWTPrincipal>()
-
-                        if (principal == null) {
-                            call.respond(401)
-                        }
-
-                        call.respondText("Hello ${principal?.payload?.subject}")
-                    }
-                }
-
-                get("/login") {
-                    val jwt = JWT.create()
-                            .withSubject("test n°" + Random().nextInt(1000))
-                            .withIssuedAt(Date())
-                            .withExpiresAt(Date(System.currentTimeMillis() + cfg.sessionDuration))
-                            .withAudience(JWT_USER_AUDIENCE)
-                            .withIssuer(cfg.name)
-                            .sign(jwtAlgorithm)
-
-                    call.respondText(jwt)
-                }
-            }
-        }
-    private fun makeJwtVerifier(issuer: String, audience: String): JWTVerifier = JWT
-            .require(jwtAlgorithm)
-            .withAudience(audience)
-            .withIssuer(issuer)
-            .build()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion = 1.3.61
+kotlinVersion = 1.3.70
 ktorVersion = 1.3.1
 jacksonVersion = 2.10.2
 exposedVersion = 0.21.1


### PR DESCRIPTION


<!-- Describe your pull request here -->
### Description

- Add Ktor Jackson support in the build dependencies to support JSON content negotiation
- Move the Ktor server in a separate class and rearrange some of the elements from this area. Also separate the JWT token creation into a separate class and remove the test routes.
- Add epilinkApiV1() function. This is where the API routes will go.
- Change some configuration parameters to have a proper server configuration that can be passed directly to the Ktor server managing class
- Add an ApiResponse<T> class to represent the general "shape" of the responses sent by the API
- Separate configuration sanity checks to a separate function, allow multiple errors to happen (i.e. log all of them *then* fail)
- Bump Kotlin to version 1.3.70

<!-- Delete the following section if this PR does not address any issues -->
#### Related issue(s)

* #11 somewhat, as this adds more KDoc. More is still needed.

<!-- Replace the [ ] by [X] to tick boxes -->
### Check-list

* [ ] This PR makes GDPR-related changes
* [X] This PR requires docs changes, but, I mean, we still don't have proper docs

