### PR TITLE
Fix HTTP requests hanging when role updates need to be done

### DIFF
--- a/bot/src/org/epilink/bot/discord/LinkDiscordBot.kt
+++ b/bot/src/org/epilink/bot/discord/LinkDiscordBot.kt
@@ -15,6 +15,7 @@ import discord4j.core.spec.EmbedCreateSpec
 import discord4j.rest.http.client.ClientException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.reactive.awaitFirstOrNull
 import kotlinx.coroutines.reactive.awaitSingle
@@ -229,6 +230,9 @@ class LinkDiscordBot(
         }
         roleManager.updateRolesOnGuilds(dbUser, guilds, discordUser, tellUserIfFailed)
     }
+
+    suspend fun launchInScope(function: suspend CoroutineScope.() -> Unit): Job =
+        scope.launch { function() }
 }
 
 private suspend fun DUser.getCheckedPrivateChannel(): PrivateChannel =

--- a/bot/src/org/epilink/bot/http/LinkBackEnd.kt
+++ b/bot/src/org/epilink/bot/http/LinkBackEnd.kt
@@ -104,7 +104,9 @@ class LinkBackEnd : KoinComponent {
                             call.receive()
                         try {
                             val u = db.createUser(this, options.keepIdentity)
-                            discord.updateRoles(u, true)
+                            discord.launchInScope {
+                                discord.updateRoles(u, true)
+                            }
                             call.loginAs(u)
                             call.respond(ApiResponse(true, "Account created, logged in."))
                         } catch (e: LinkException) {
@@ -171,6 +173,7 @@ class LinkBackEnd : KoinComponent {
             )
         }
     }
+
     /**
      * Take a Microsoft authorization code, consume it and apply the information retrieve form it to the current
      * registration session


### PR DESCRIPTION
### Description

A simple fix for #28: just launch the role update in the background. We are using the Discord bot's coroutine scope to avoid leaking that (although the coroutine scope can't really, huh, leak anything, because its lifespan is strictly equal to the lifespan of the entire server right now).

#### Related issue(s)

Fixes #28 

### Check-list

* [ ] This PR makes GDPR-related changes
* [ ] This PR requires docs changes

