### PR TITLE
Add culprit guilds' names to automated ID access notifications that are caused by role updates

### DIFF
--- a/bot/src/org/epilink/bot/discord/LinkRoleManager.kt
+++ b/bot/src/org/epilink/bot/discord/LinkRoleManager.kt
@@ -91,6 +91,11 @@ class LinkRoleManager : KoinComponent {
                         dbUser,
                         ev.member,
                         getRulesRelevantForGuilds(guild).map { it.first },
+                        // We can put the guild name here even if the guild does not require strong rules
+                        // because this argument is ignored if no such rule is used.
+                        // So, either a strong rule is used and the only guild it can be used on is [guild], or
+                        // there is no strong rule at all and this is ignored. So we can just pass the guild in
+                        // either way.
                         listOf(guild.name)
                     )
                 )
@@ -114,7 +119,7 @@ class LinkRoleManager : KoinComponent {
     ): List<Pair<Rule, Set<String>>> = withContext(Dispatchers.Default) {
         // Maps role names to their rules in the global config
         val rolesInGlobalConfig = config.roles.associateBy({ it.name }, { it.rule })
-        return guilds
+        guilds
             // Get each guild's config, paired with the guild's name
             .map { it.name to config.getConfigForGuild(it.id.asString()) } // List<Pair<Guild name, Guild config>>
             // Get the EpiLink roles required by each guild, paired with the guild's name


### PR DESCRIPTION
### Description

Add culprit guilds' names to automated ID access notifications that are caused by role updates.

Before:

![image](https://user-images.githubusercontent.com/5175705/77494000-4527e100-6e4d-11ea-9fa5-1afcbc8b0cb1.png)

After:

![image](https://user-images.githubusercontent.com/5175705/77494019-4fe27600-6e4d-11ea-97e5-911e3ac7aa52.png)

Also overhauls an internal function to also report on which guilds require which rules.

This should still be replaced by an embed to look better but that's trivial.

#### Related issue(s)

Fixes #26 

### Check-list

* [X] This PR makes GDPR-related changes. Improves transparency.
* [ ] This PR requires docs changes

