### PR TITLE
Add nicer and safer error handling

### DIFF
--- a/bot/src/org/epilink/bot/LinkDisplayableException.kt
+++ b/bot/src/org/epilink/bot/LinkDisplayableException.kt
@@ -1,0 +1,14 @@
+package org.epilink.bot
+
+/**
+ * Exceptions handled within EpiLink should be using the LinkException type.
+ *
+ * @see LinkDisplayableException
+ */
+open class LinkException(message: String, cause: Throwable? = null) : Exception(message, cause)
+
+/**
+ * An exception that happens within EpiLink whose message is end-user friendly.
+ */
+open class LinkDisplayableException(displayableMessage: String, val isEndUserAtFault: Boolean, cause: Throwable? = null) :
+    LinkException(displayableMessage, cause)

--- a/bot/src/org/epilink/bot/LinkException.kt
+++ b/bot/src/org/epilink/bot/LinkException.kt
@@ -1,3 +1,0 @@
-package org.epilink.bot
-
-open class LinkException(message: String? = null, cause: Exception? = null) : Exception(message, cause)

--- a/bot/src/org/epilink/bot/discord/LinkRoleManager.kt
+++ b/bot/src/org/epilink/bot/discord/LinkRoleManager.kt
@@ -7,6 +7,8 @@ import discord4j.core.event.domain.guild.MemberJoinEvent
 import discord4j.rest.http.client.ClientException
 import kotlinx.coroutines.*
 import kotlinx.coroutines.reactive.awaitSingle
+import org.epilink.bot.LinkDisplayableException
+import org.epilink.bot.LinkException
 import org.epilink.bot.config.LinkDiscordConfig
 import org.epilink.bot.config.rulebook.Rule
 import org.epilink.bot.config.rulebook.Rulebook
@@ -31,6 +33,8 @@ class LinkRoleManager : KoinComponent {
      * Updates all the roles of a Discord user on a given collection of guilds. The user does not have to be present on
      * the given guilds -- this function handles the case where the member is absent well. If tellUserIfFailed is true,
      * this additionally sends the user a DM on why the roles may have failed to update (e.g. banned user).
+     *
+     * @throws LinkDisplayableException If something fails during the member retrieval from each guild.
      */
     suspend fun updateRolesOnGuilds(
         dbUser: User,
@@ -56,7 +60,7 @@ class LinkRoleManager : KoinComponent {
                         if (ex.errorCode == "10007") {
                             null // Simply ignore this one
                         } else {
-                            throw ex
+                            throw LinkException("Unexpected exception upon member retrieval for guild ${g.name}", ex)
                         }
                     }
                 }

--- a/bot/src/org/epilink/bot/discord/UserDoesNotAcceptPrivateMessagesException.kt
+++ b/bot/src/org/epilink/bot/discord/UserDoesNotAcceptPrivateMessagesException.kt
@@ -1,9 +1,10 @@
 package org.epilink.bot.discord
 
 import discord4j.rest.http.client.ClientException
-import org.epilink.bot.LinkException
+import org.epilink.bot.LinkDisplayableException
 
 /**
  * Used to signal that a user did not accept private messages
  */
-class UserDoesNotAcceptPrivateMessagesException(ex: ClientException) : LinkException(cause = ex)
+class UserDoesNotAcceptPrivateMessagesException(ex: ClientException) :
+    LinkDisplayableException("This Discord account does not accept private messages.", true, cause = ex)

--- a/bot/src/org/epilink/bot/http/LinkDiscordBackEnd.kt
+++ b/bot/src/org/epilink/bot/http/LinkDiscordBackEnd.kt
@@ -10,6 +10,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.ParametersBuilder
 import io.ktor.http.formUrlEncode
+import org.epilink.bot.LinkDisplayableException
+import org.epilink.bot.LinkException
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 
@@ -34,29 +36,49 @@ class LinkDiscordBackEnd(
      * @param authcode The authorization code to consume
      * @param redirectUri The redirect_uri that was used in the authorization request that returned the authorization
      * code
+     * @throws LinkException If something wrong happens while contacting the Discord APIs.
      */
     suspend fun getDiscordToken(authcode: String, redirectUri: String): String {
-        val res = client.post<String>("https://discordapp.com/api/v6/oauth2/token") {
-            header(HttpHeaders.Accept, ContentType.Application.Json)
-            body = TextContent(
-                ParametersBuilder().apply {
-                    appendOauthParameters(clientId, secret, authcode, redirectUri)
-                }.build().formUrlEncode(),
-                ContentType.Application.FormUrlEncoded
-            )
+        val res = runCatching {
+            client.post<String>("https://discordapp.com/api/v6/oauth2/token") {
+                header(HttpHeaders.Accept, ContentType.Application.Json)
+                body = TextContent(
+                    ParametersBuilder().apply {
+                        appendOauthParameters(clientId, secret, authcode, redirectUri)
+                    }.build().formUrlEncode(),
+                    ContentType.Application.FormUrlEncoded
+                )
+            }
+        }.getOrElse {
+            throw LinkException("Failed to contact Discord servers for token retrieval.")
         }
         val data: Map<String, Any?> = ObjectMapper().readValue(res)
-        return data["access_token"] as String? ?: error("Did not receive any access token from Discord")
+        (data["error"] as? String)?.let {
+            if (it == "invalid_grant")
+                throw LinkDisplayableException("Invalid authorization code", true)
+            else
+                throw LinkException("Discord OAuth failed: $it (" + (data["error_description"] ?: "no description") + ")")
+        }
+        return data["access_token"] as String? ?: throw LinkException("Did not receive any access token from Discord")
     }
 
     /**
      * Retrieve a user's own information using a Discord OAuth2 token.
+     *
+     * @throws LinkException If something wrong happens while contacting the Discord APIs
      */
     suspend fun getDiscordInfo(token: String): DiscordUserInfo {
-        val data = client.getJson("https://discordapp.com/api/v6/users/@me", bearer = token)
-        val userid = data["id"] as String? ?: error("Missing Discord ID")
-        val username = data["username"] as String? ?: error("Missing Discord username")
-        val discriminator = data["discriminator"] as String? ?: error("Missing Discord discriminator")
+        val data = runCatching {
+            client.getJson("https://discordapp.com/api/v6/users/@me", bearer = token)
+        }.getOrElse {
+            throw LinkException("Failed to contact Discord servers for user information retrieval.")
+        }
+        val userid = data["id"] as String?
+            ?: throw LinkException("Missing Discord ID in Discord API response")
+        val username = data["username"] as String?
+            ?: throw LinkException("Missing Discord username in Discord API response")
+        val discriminator = data["discriminator"] as String?
+            ?: throw LinkException("Missing Discord discriminator in Discord API response")
         val displayableUsername = "$username#$discriminator"
         val avatarHash = data["avatar"] as String?
         val avatar =


### PR DESCRIPTION
### Description

Replace generic errors with LinkExceptions, which we then catch on our end. Also make sure to return ApiResponse objects in the case of an uncaught exception, and generally log everything.

Kind of half-assed but hey, it's better than what we were doing previously.

#### Related issue(s)

Fixes #22

### Check-list

* [ ] This PR makes GDPR-related changes
* [ ] This PR requires docs changes
