### PR TITLE
Add identifiable information to user endpoint

### DIFF
--- a/bot/src/main/kotlin/org/epilink/bot/http/data/UserInformation.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/data/UserInformation.kt
@@ -1,10 +1,13 @@
 package org.epilink.bot.http.data
 
+import org.epilink.bot.db.UsesTrueIdentity
 
 // See the Api.md documentation file for more information
 @Suppress("KDocMissingDocumentation")
 data class UserInformation(
     val discordId: String,
     val username: String,
-    val avatarUrl: String?
+    val avatarUrl: String?,
+    @UsesTrueIdentity
+    val identifiable: Boolean
 )

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -308,7 +308,8 @@ Contains information about the currently logged in user.
 {
     "discordId": "...",
     "username": "...",
-    "avatarUrl": "..." // nullable
+    "avatarUrl": "...", // nullable
+    "identifiable": true // or false
 }
 ```
 
@@ -316,7 +317,8 @@ Where:
 
 * `discordId` is the Discord ID of the user
 * `username` is the Discord username of the user (should be displayed as the normal username in the interface). For example `My awesome name#1234`
-* `avatarUrl` (may be null) is a URL to the Discord avatar of the user, or null if Discord did not reply with any URL. 
+* `avatarUrl` (may be null) is a URL to the Discord avatar of the user, or null if Discord did not reply with any URL.
+* `identifiable` is a boolean. If true, the user has their identity recorded in the database. If false, the user does not have their identity in the database. 
 
 #### IdAccessLogs
 


### PR DESCRIPTION
### Description

This PR adds a `identifiable` field to the `GET /api/v1/user` endpoint

#### Related issue(s)

Fixes #75 

### Check-list

* [ ] This PR makes GDPR-related changes
* [X] This PR requires docs changes. Changes made.

