### PR TITLE
[CRAP] Package EpiLink as a snap

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+# Deploy default config files if they do not already exist (-n)
+cp -n $SNAP/defaults/* $SNAP_COMMON
+
+sed -i -e "s:dir ./:dir $SNAP_COMMON/redis/:g" $SNAP_COMMON/redis.conf
+
+REDIS_DIR=$SNAP_COMMON/redis
+
+if [ ! -d $REDIS_DIR ]; then
+    # Data folder does not exist, create it
+    mkdir $REDIS_DIR
+    # from https://snapcraft.io/docs/system-usernames section Ownership
+    chmod 770 "$REDIS_DIR"
+    chown snap_daemon "$REDIS_DIR"
+    chgrp root "$REDIS_DIR"
+fi

--- a/snap/local/epilink_start
+++ b/snap/local/epilink_start
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+cd $SNAP_COMMON
+exec $SNAP/epilink/bin/bot $SNAP_COMMON/epilink_config.yaml

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,72 @@
+name: epilink
+version: git
+summary: Discord + Microsoft account linking server
+description: |
+  EpiLink is an open-source account linker that allows you to bind Discord and
+  Microsoft identities together and only allow specific people in your Discord
+  servers. You can also automatically attribute roles based on who is who.
+
+grade: devel
+
+confinement: strict
+base: core18
+
+parts:
+  # EpiLink
+  epilink:
+    source: '.'
+    plugin: gradle
+    gradle-openjdk-version: "11"
+    gradle-options: [installDist, -PwithFrontend]
+    gradle-output-dir: bot/build/libs
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/epilink
+      mkdir -p $SNAPCRAFT_PART_INSTALL/defaults
+      cp -r bot/build/install/bot/* $SNAPCRAFT_PART_INSTALL/epilink
+      cp bot/config/epilink_config.yaml $SNAPCRAFT_PART_INSTALL/defaults
+      cp snap/local/epilink_start $SNAPCRAFT_PART_INSTALL/bin
+  # Redis
+  redis:
+    source: http://download.redis.io/releases/redis-5.0.8.tar.gz
+    plugin: make
+    artifacts:
+      - src/redis-sentinel
+      - src/redis-server
+      - src/redis-check-aof
+      - src/redis-check-rdb
+      - src/redis-cli
+    override-build: |
+      snapcraftctl build
+      mkdir -p $SNAPCRAFT_PART_INSTALL/defaults
+      cp redis.conf $SNAPCRAFT_PART_INSTALL/defaults
+    organize:
+      src/redis-server: bin/redis-server
+      src/redis-check-aof: bin/redis-check-aof
+      src/redis-check-rdb: bin/redis-check-rdb
+      src/redis-cli: bin/redis-cli
+    build-packages:
+      - build-essential
+
+
+apps:
+  epilink:
+    command: bin/epilink_start
+    plugs: [network, network-bind, removable-media]
+    daemon: simple
+  redis-check-rdb:
+    command: bin/redis-check-rdb
+    plugs: [network]
+  redis-check-aof:
+    command: bin/redis-check-aof
+    plugs: [network]
+  redis-cli:
+    command: bin/redis-cli
+    plugs: [network]
+  redis-server:
+    command: bin/redis-server $SNAP_COMMON/redis.conf
+    plugs: [network, network-bind, removable-media]
+    daemon: simple
+
+system-usernames:
+  snap_daemon: shared

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -67,3 +67,8 @@ license {
 
 licenseFormat.dependsOn licenseFormatJs
 tasks["license"].dependsOn licenseCheckJs
+
+node {
+  version = '12.16.2'
+  download = true
+}


### PR DESCRIPTION
**This is crap, don't merge it, don't even look at it, it will burn your eyes**

### Description

An attempt at making a snap.

#### Related issue(s)

Fixes something, maybe

* [x] Blocked by #92 
* [x] Blocked by #95 

### TODO

* [x] Actually check that it works
* [x] ~~Make the redis config log to syslog~~ Unnecessary, stdout is picked up successfully by `snapd`
* [ ] Check that `snap logs` works (or at least journalctl shows stuff). [Forum thread on snapcraft.io](https://forum.snapcraft.io/t/snap-logs-does-not-show-the-logs-even-though-they-are-in-journalctl/16850)
* (blocking point for 92 and 95, properly building the snap requires sane defaults through configuration and the ability to properly specify the back-end location instead of hacking the Api.js file)
* [ ] Automatically build and publish the snap to the snap store
* [ ] Check if putting stuff on remote media is supported
* [ ] Update the docs with the changes that have been made
* [ ] Update `CHANGELOG.md`
