### PR TITLE
Remove HTTPS redirection on the back-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* Various building fixes (#118, #110)
-* Fixed CORS support on HTTPS (#115)
 * Added the ability to set a logo on the back-end (#111)
+
+### Fixed
+
+* Fixed CORS support on HTTPS (#115)
+* Various building fixes (#118, #110)
+
+### Removed
+
+* Removed HTTPS redirection options (#120)
 
 ## 0.1
 

--- a/bot/config/epilink_config.yaml
+++ b/bot/config/epilink_config.yaml
@@ -17,9 +17,6 @@ name: My EpiLink Instance
 server:
   # The port that should be used for the server.
   port: 9090
-  # True to enable HTTPS redirection for all HTTP connections, false to allow HTTP connections.
-  # !!SWITCH TO TRUE FOR PRODUCTION SYSTEMS!!
-  enableHttpsRedirect: false
   # Either None, Forwarded or XForwarded depending on how you use your reverse proxy to transmit the remote host's
   # information
   # !!SWITCH TO THE CORRECT VALUE! FAILURE TO DO SO COULD LEAD TO SECURITY FLAWS!!

--- a/bot/src/main/kotlin/org/epilink/bot/config/LinkConfig.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/config/LinkConfig.kt
@@ -89,10 +89,6 @@ data class LinkWebServerConfiguration(
      */
     val port: Int,
     /**
-     * True if HTTP requests should be redirected to HTTPS, false if HTTP requests should be allowed
-     */
-    val enableHttpsRedirect: Boolean,
-    /**
      * Determine which (possibly de-facto) standard to follow for proxy headers support.
      */
     val proxyType: ProxyType,

--- a/bot/src/main/kotlin/org/epilink/bot/http/LinkHttpServer.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/LinkHttpServer.kt
@@ -50,17 +50,11 @@ internal class LinkHttpServerImpl : LinkHttpServer, KoinComponent {
      */
     private var server: ApplicationEngine = embeddedServer(Netty, wsCfg.port) {
         when (wsCfg.proxyType) {
-            None -> logger.info("Reverse proxy support is DISABLED.")
+            None -> logger.warn("Reverse proxy support is DISABLED. Use a reverse proxy and configure it for HTTPS!")
             Forwarded -> install(ForwardedHeaderSupport)
                 .also { logger.debug { "'Forwarded' header support installed." } }
             XForwarded -> install(XForwardedHeaderSupport)
                 .also { logger.debug { "'X-Forwarded-*' header support installed." } }
-        }
-        if (wsCfg.enableHttpsRedirect) {
-            install(HttpsRedirect)
-            logger.debug { "HTTPS redirection installed." }
-        } else {
-            logger.warn("HTTPS redirection is DISABLED.")
         }
         logger.debug("Installing EpiLink API")
         with(backend) { epilinkApiModule() }

--- a/bot/src/test/kotlin/org/epilink/bot/TestUtils.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/TestUtils.kt
@@ -29,7 +29,7 @@ import kotlin.test.assertEquals
 
 val minimalConfig = LinkConfiguration(
     "Test",
-    server = LinkWebServerConfiguration(0, false, ProxyType.None, null),
+    server = LinkWebServerConfiguration(0, ProxyType.None, null),
     db = "",
     tokens = LinkTokens(
         discordToken = "",

--- a/docs/MaintainerGuide.md
+++ b/docs/MaintainerGuide.md
@@ -12,7 +12,7 @@ Go through all of these steps before going public:
 - [Configure it](#configuration) using the [sample configuration](/bot/config/epilink_config.yaml) as a template
 - Make sure everything works
 - Place EpiLink behind a reverse proxy and enable HTTPS through your reverse proxy
-- Enable [HTTPS redirection and set the reverse proxy headers configuration](#http-server-settings)
+- [Set the reverse proxy headers configuration](#http-server-settings)
 - Make sure everything still works
 
 After doing all that, you will be good to go! Read on to learn how to do all of these things!
@@ -28,7 +28,7 @@ All-in-one is recommended for most use cases, although it is not necessarily the
 
 You will also need a Redis server. All-in-one packages may include a ready-to-use Redis server.
 
-**EpiLink requires HTTPS and must be put behind a reverse proxy which passes remote host information in the `X-Forwarded-*` headers.** You should use the reverse proxy to add HTTPS via something like Let's Encrypt.
+**EpiLink requires HTTPS and must be put behind a reverse proxy which passes remote host information in the `X-Forwarded-*` or `Forwarded` headers.** You should use the reverse proxy to add HTTPS via something like Let's Encrypt.
 
 **If, somehow, you do not use a reverse proxy, launch EpiLink with the `-n` option.** Otherwise, attackers could fake their IP address by passing their own `X-Forwarded-*` headers.
 
@@ -69,7 +69,6 @@ redis: "redis://localhost:6379"
 server:
   port: 9090
   frontendUrl: ~
-  enableHttpsRedirect: true # or false, but should be true for production systems. Only use false for testing!
   proxyType: None # or XForwarded, or Forwarded
   logo: "https://..." # optional
   footers: # optional
@@ -81,7 +80,6 @@ server:
 
 * `port`: The port on which the back-end will be served
 * `frontendUrl`: The URL of the front-end *WITH A TRAILING SLASH* (e.g. `https://myfrontend.com/`), or `~` if the front-end is unknown, or you are using the all-in-one packages (i.e. the front-end is bundled with the back-end).
-* `enableHttpsRedirect` ***SECURITY***: Enables HTTPS redirection for all HTTP requests when set to true. Setting it to false causes EpiLink to accept HTTP request -- which you should only do if you are testing things.
 * `proxyType` ***SECURITY***: Tells EpiLink how the reverse proxy it is behind passes down remote host information.
     * `None`: For testing only, when EpiLink is not behind a reverse proxy at all.
     * `XForwarded`: When remote host information is passed through the `X-Forwarded-*` headers.


### PR DESCRIPTION
### Description

Because that's the reverse proxy's job, not ours

#### Related issue(s)

Fixes #117 

### TODO

* [X] Update the docs with the changes that have been made
* [x] Update `CHANGELOG.md`
