### PR TITLE
Implement better getThing for generic maps and lists for rulebooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.1.1
+## ([Unreleased]) 0.2
+
+### Added
+
+* Added more helpers for manipulating received objects in rulebooks (and documented networking capabilities) ([#132](https://github.com/EpiLink/EpiLink/issues/132))
+
+## [0.1.1] - 2020-04-25
+
+Emergency fixes.
 
 ### Added
 
@@ -24,7 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Removed HTTPS redirection options ([#120](https://github.com/EpiLink/EpiLink/issues/120)). 
   * **BREAKING CHANGE:** Delete the `enableHttpsRedirect` option in your configuration file.
 
-## 0.1
+## [0.1.0] - 2020-04-25
 
 Initial release. Introduces so many things it will make your eyes hurt, probably.
 
@@ -59,3 +67,7 @@ Initial release. Introduces so many things it will make your eyes hurt, probably
 * Added Ktor server and back-end server ([#5](https://github.com/EpiLink/EpiLink/issues/5), [#13](https://github.com/EpiLink/EpiLink/issues/13))
 * Added basic GitHub project management via CI and code owners ([#4](https://github.com/EpiLink/EpiLink/issues/4), [#49](https://github.com/EpiLink/EpiLink/issues/49))
 * Added basic Gradle project ([#2](https://github.com/EpiLink/EpiLink/issues/2))
+
+[Unreleased]: https://github.com/EpiLink/EpiLink/compare/v0.1.1...dev
+[0.1.1]: https://github.com/EpiLink/EpiLink/releases/tag/v0.1.1
+[0.1.0]: https://github.com/EpiLink/EpiLink/releases/tag/v0.1

--- a/bot/src/main/kotlin/org/epilink/bot/config/rulebook/QuickHttp.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/config/rulebook/QuickHttp.kt
@@ -69,3 +69,33 @@ suspend fun httpGetJson(
 
     return withContext(Dispatchers.Default) { ObjectMapper().readValue(response) }
 }
+
+/**
+ * Get a key, where the value is expected to be a map
+ */
+fun Map<*, *>.getMap(key: String) = this[key] as? Map<*, *> ?: error("Invalid format, $key is not a map")
+
+/**
+ * Get a key, where the value is expected to be a list
+ */
+fun Map<*, *>.getList(key: String) = this[key] as? List<*> ?: error("Invalid format, $key is not a list")
+
+/**
+ * Get a key, where the value is expected to be a string
+ */
+fun Map<*, *>.getString(key: String) = this[key] as? String ?: error("Invalid format, $key is not a string")
+
+/**
+ * Get a value at an index, where the value is expected to be a map
+ */
+fun List<*>.getMap(index: Int) = this[index] as? Map<*, *> ?: error("Invalid format, value at index $index is not a map")
+
+/**
+ * Get the value at an index, where the value is expected to be a list
+ */
+fun List<*>.getList(index: Int) = this[index] as? List<*> ?: error("Invalid format, value at index $index is not a list")
+
+/**
+ * Get the value at an index, where the value is expected to be a string
+ */
+fun List<*>.getString(index: Int) = this[index] as? String ?: error("Invalid format, value at index $index is not a string")

--- a/bot/src/test/kotlin/org/epilink/bot/rulebooks/RulebookHelpersTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/rulebooks/RulebookHelpersTest.kt
@@ -1,3 +1,11 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
 package org.epilink.bot.rulebooks
 
 import org.epilink.bot.config.rulebook.*

--- a/bot/src/test/kotlin/org/epilink/bot/rulebooks/RulebookHelpersTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/rulebooks/RulebookHelpersTest.kt
@@ -1,0 +1,90 @@
+package org.epilink.bot.rulebooks
+
+import org.epilink.bot.config.rulebook.*
+import kotlin.test.*
+
+class RulebookHelpersTest {
+    private val innerMap = mapOf("hmmmm" to "yes", "x" to 'y', "E" to 53, "x" to null)
+    private val innerList = listOf("no", "maybe", "ey", 59)
+    private val mapTest = mapOf(
+        "potatoes" to "carrots",
+        "yes" to innerList,
+        "nice" to "not so nice",
+        "thonk" to innerMap,
+        "hey" to null,
+        "hello" to 99
+    )
+    private val listTest = listOf("a", 'b', 3, innerMap, null, "floor", innerList)
+
+    @Test
+    fun `Test Map getMap`() {
+        assertSame(innerMap, mapTest.getMap("thonk"))
+    }
+
+    @Test
+    fun `Test Map getMap cast error`() {
+        assertFails { mapTest.getMap("yes") }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+
+    @Test
+    fun `Test Map getString`() {
+        assertEquals("carrots", mapTest.getString("potatoes"))
+    }
+
+    @Test
+    fun `Test Map getString cast error`() {
+        assertFails { mapTest.getString("hello") }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+
+    @Test
+    fun `Test Map getList`() {
+        assertSame(innerList, mapTest.getList("yes"))
+    }
+
+    @Test
+    fun `Test Map getList cast error`() {
+        assertFails { mapTest.getList("thonk") }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+
+    @Test
+    fun `Test List getMap`() {
+        assertSame(innerMap, listTest.getMap(3))
+    }
+
+    @Test
+    fun `Test List getMap cast error`() {
+        assertFails { listTest.getMap(1) }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+
+    @Test
+    fun `Test List getString`() {
+        assertEquals("floor", listTest.getString(5))
+    }
+
+    @Test
+    fun `Test List getString cast error`() {
+        assertFails { listTest.getString(2) }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+
+    @Test
+    fun `Test List getList`() {
+        assertSame(innerList, listTest.getList(6))
+    }
+
+    @Test
+    fun `Test List getList cast error`() {
+        assertFails { listTest.getList(0) }.apply {
+            assert(message!!.contains("Invalid format"))
+        }
+    }
+}


### PR DESCRIPTION
### Description

Implements more functionality for generic maps and lists, which is especially useful for rulebooks which had to awkwardly cast them all over the place before.

#### Related issue(s)

Fixes #27 

### TODO

* [ ] Update the docs with the changes that have been made
* [ ] Update `CHANGELOG.md`
