### PR TITLE
Add an error for when frontendUrl does not have a trailing slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+* Added an error for when the `frontendUrl` configuration property does not have a trailing slash ([150](https://github.com/EpiLink/EpiLink/pull/150))
 * Added the "Instance" page on the front-end ([#148](https://github.com/EpiLink/EpiLink/issues/148))
 * Added maintainer information in the back-end configuration + endpoints ([#148](https://github.com/EpiLink/EpiLink/issues/148))
 * Added a back arrow button on the meta text pages ([#141](https://github.com/EpiLink/EpiLink/issues/141))

--- a/bot/src/main/kotlin/org/epilink/bot/config/LinkConfig.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/config/LinkConfig.kt
@@ -391,9 +391,12 @@ fun LinkTokens.check(): List<ConfigReportElement> {
 /**
  * Check the web server's configuration
  */
-@Suppress("unused")
 fun LinkWebServerConfiguration.check(): List<ConfigReportElement> {
-    return listOf()
+    val reports = mutableListOf<ConfigReportElement>()
+    if (this.frontendUrl?.endsWith("/") == false) { // Equality check because left side can be null
+        reports += ConfigError(true, "The frontendUrl value in the server config must have a trailing slash (add a / at the end of your URL)")
+    }
+    return reports
 }
 
 /**

--- a/bot/src/test/kotlin/org/epilink/bot/ConfigTestCheck.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/ConfigTestCheck.kt
@@ -10,10 +10,7 @@ package org.epilink.bot
 
 import io.mockk.every
 import io.mockk.mockk
-import org.epilink.bot.config.ConfigError
-import org.epilink.bot.config.ConfigWarning
-import org.epilink.bot.config.LinkLegalConfiguration
-import org.epilink.bot.config.check
+import org.epilink.bot.config.*
 import kotlin.test.*
 
 class ConfigTestCheck {
@@ -85,5 +82,14 @@ class ConfigTestCheck {
         }
         val reports = config.check()
         assertTrue(reports.any { it is ConfigWarning && it.message.contains("identityPromptText") })
+    }
+
+    @Test
+    fun `Test no trailing slash at end of front-end URL triggers error`() {
+        val config = mockk<LinkWebServerConfiguration> {
+            every { frontendUrl } returns "https://whereismy.slash"
+        }
+        val reports = config.check()
+        assertTrue(reports.any { it is ConfigError && it.shouldFail && it.message.contains("frontendUrl")})
     }
 }


### PR DESCRIPTION
## Description

I mean, just read the title

#### Related issue(s)

Fixes #145 

### TODO

* [x] Update `CHANGELOG.md`
