### PR TITLE
Add GDPR report generator code and endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+* Added GDPR report generation ([#173](https://github.com/EpiLink/EpiLink/pull/173))
 * Added ban notifications ([#168](https://github.com/EpiLink/EpiLink/pull/168))
 * Added administration endpoints (and its documentation) ([#161](https://github.com/EpiLink/EpiLink/pull/161))
 * Added banning abilities ([#161](https://github.com/EpiLink/EpiLink/pull/161))

--- a/bot/src/main/kotlin/org/epilink/bot/LinkServerEnvironment.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/LinkServerEnvironment.kt
@@ -61,6 +61,8 @@ class LinkServerEnvironment(
         single<LinkPermissionChecks> { LinkPermissionChecksImpl() }
         // User creation logic
         single<LinkUserCreator> { LinkUserCreatorImpl() }
+        // GDPR report generation utility
+        single<LinkGdprReport> { LinkGdprReportImpl() }
     }
 
     /**

--- a/bot/src/main/kotlin/org/epilink/bot/LogUtils.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/LogUtils.kt
@@ -14,7 +14,7 @@ import org.slf4j.Logger
  * Send a lazily constructed debug message only if debug logging is enabled
  */
 inline fun Logger.debug(lazyMsg: () -> String) {
-    if(isDebugEnabled) {
+    if (isDebugEnabled) {
         debug(lazyMsg())
     }
 }
@@ -23,7 +23,7 @@ inline fun Logger.debug(lazyMsg: () -> String) {
  * Send a lazily constructed debug message only if debug logging is enabled
  */
 inline fun Logger.debug(ex: Throwable, lazyMsg: () -> String) {
-    if(isDebugEnabled) {
+    if (isDebugEnabled) {
         debug(lazyMsg(), ex)
     }
 }
@@ -32,7 +32,7 @@ inline fun Logger.debug(ex: Throwable, lazyMsg: () -> String) {
  * Send a lazily constructed trace message only if trace logging is enabled
  */
 inline fun Logger.trace(lazyMsg: () -> String) {
-    if(isTraceEnabled) {
+    if (isTraceEnabled) {
         trace(lazyMsg())
     }
 }
@@ -41,7 +41,7 @@ inline fun Logger.trace(lazyMsg: () -> String) {
  * Send the given info message if debug is disabled, or the given debug message if debug is enabled
  */
 inline fun Logger.infoOrDebug(infoMessage: String, lazyDebugMsg: () -> String) {
-    if(isDebugEnabled) {
+    if (isDebugEnabled) {
         debug(lazyDebugMsg())
     } else {
         info(infoMessage)

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
@@ -1,0 +1,136 @@
+package org.epilink.bot.db
+
+import org.epilink.bot.LinkServerEnvironment
+import org.epilink.bot.config.LinkPrivacy
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+import java.time.Instant
+
+interface LinkGdprReport {
+    suspend fun getFullReport(user: LinkUser): String
+    fun getUserInfoReport(user: LinkUser): String
+    suspend fun getTrueIdentityReport(user: LinkUser): String
+    suspend fun getBanReport(user: LinkUser): String
+    suspend fun getIdentityAccessesReport(user: LinkUser): String
+}
+
+internal class LinkGdprReportImpl : LinkGdprReport, KoinComponent {
+    private val dbf: LinkDatabaseFacade by inject()
+    private val idManager: LinkIdManager by inject()
+    private val banLogic: LinkBanLogic by inject()
+    private val privacy: LinkPrivacy by inject()
+    private val env: LinkServerEnvironment by inject()
+
+    override suspend fun getFullReport(user: LinkUser): String =
+        """
+        |# ${env.name} GDPR report for user ${user.discordId}
+        |
+        |This GDPR report contains information stored about you in this instance's database(1).
+        |
+        |This report was made on ${Instant.now()}. For any request, please contact an instance administrator.
+        |
+        |${getUserInfoReport(user)}
+        |
+        |${getTrueIdentityReport(user)}
+        |
+        |${getBanReport(user)}
+        |
+        |${getIdentityAccessesReport(user)}
+        |
+        |(end of report)
+        |   
+        |(1): More information may be *temporarily* stored in caches, and is not included here. This information may contain your Discord username, avatar and roles. This information is stored temporarily and will be deleted after some time.
+        """.trimMargin()
+
+    override fun getUserInfoReport(user: LinkUser): String = with(user) {
+        """
+        ## User information
+        
+        General information stored about your account.
+        
+        - Discord ID: $discordId
+        - Microsoft ID hash (Base64 URL-safe encoded): ${user.msftIdHash.encodeBase64Url()}
+        - Account creation timestamp: $creationDate
+        """.trimIndent()
+    }
+
+    private fun ByteArray.encodeBase64Url() =
+        java.util.Base64.getUrlEncoder().encodeToString(this)
+
+    @OptIn(UsesTrueIdentity::class) // Reports true identity, so huh, yeah
+    override suspend fun getTrueIdentityReport(user: LinkUser): String = with(user) {
+        if (dbf.isUserIdentifiable(this)) {
+            val identity = idManager.accessIdentity(
+                this,
+                true,
+                "EpiLink GDPR Report Service",
+                "Your identity was retrieved in order to generate a GDPR report."
+            )
+            """
+            ## Identity information
+            
+            Information stored because you enabled the "Remember my identity" feature.
+            
+            - True identity: $identity
+            """.trimIndent()
+        } else {
+            """
+            ## Identity information
+            
+            You did not enable the "Remember my identity" feature.
+            
+            - True identity: Not stored.
+            """.trimIndent()
+        }
+    }
+
+    override suspend fun getBanReport(user: LinkUser): String =
+        """
+        |## Ban information
+        |
+        |The following list contains all of the bans against you.
+        |
+        |${makeBansList(user) ?: "No known bans."}
+        """.trimMargin()
+
+    private suspend fun makeBansList(user: LinkUser): String? {
+        val bans = dbf.getBansFor(user.msftIdHash)
+        return if (bans.isEmpty()) {
+            null
+        } else {
+            bans.joinToString("\n") {
+                """
+                |- Ban ${if (it.revoked) "(revoked, inactive)" else if (banLogic.isBanActive(it)) "(active)" else "(expired/inactive)"}
+                |  - Reason: ${it.reason}
+                |  - Issued on: ${it.issued}
+                |  - Expires on: ${it.expiresOn ?: "Does not expire"}
+                """.trimMargin()
+            }
+        }
+    }
+
+    override suspend fun getIdentityAccessesReport(user: LinkUser): String =
+        """
+        |## ID Accesses information
+        |
+        |List of accesses made to your identity.
+        |
+        |${makeIdAccessList(user) ?: "No known ID access."}
+        """.trimMargin()
+
+    private suspend fun makeIdAccessList(user: LinkUser): String? {
+        val idAccesses = dbf.getIdentityAccessesFor(user)
+        return if (idAccesses.isEmpty()) {
+            null
+        } else {
+            idAccesses.joinToString("\n") {
+                """
+                |- ID Access made on ${it.timestamp} ${if (it.automated) "automatically" else "manually"}
+                |  - Requester: ${if (privacy.shouldDiscloseIdentity(it.automated)) it.authorName else "(undisclosed)"}
+                |  - Reason: ${it.reason}
+                """.trimMargin()
+            }
+        }
+    }
+
+}

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
@@ -1,3 +1,11 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
 package org.epilink.bot.db
 
 import org.epilink.bot.LinkServerEnvironment

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
@@ -14,11 +14,37 @@ import org.koin.core.KoinComponent
 import org.koin.core.inject
 import java.time.Instant
 
+/**
+ * Component that generates human-readable reports on someone's information that is stored in the database.
+ */
 interface LinkGdprReport {
+    /**
+     * Generate a full report that contains everything this component can generate
+     */
     suspend fun getFullReport(user: LinkUser, requester: String): String
+
+    /**
+     * Generate a report on the user's information (Discord ID, Microsoft ID hash, creation timestamp)
+     */
     fun getUserInfoReport(user: LinkUser): String
+
+    /**
+     * Generate a report on the user's true identity. Generates an ID access request that is disclosed as manual, with
+     * [requester] as the author.
+     *
+     * This should be called before [getIdentityAccessesReport] since this generates an additional ID access.
+     */
     suspend fun getTrueIdentityReport(user: LinkUser, requester: String): String
+
+    /**
+     * Generate a report on the user's bans. It also indicates which ban are revoked, expired or active.
+     */
     suspend fun getBanReport(user: LinkUser): String
+
+    /**
+     * Generate a report on the user's identity accesses. This includes the name of human requester following the
+     * privacy config.
+     */
     suspend fun getIdentityAccessesReport(user: LinkUser): String
 }
 

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkGdprReport.kt
@@ -15,9 +15,9 @@ import org.koin.core.inject
 import java.time.Instant
 
 interface LinkGdprReport {
-    suspend fun getFullReport(user: LinkUser): String
+    suspend fun getFullReport(user: LinkUser, requester: String): String
     fun getUserInfoReport(user: LinkUser): String
-    suspend fun getTrueIdentityReport(user: LinkUser): String
+    suspend fun getTrueIdentityReport(user: LinkUser, requester: String): String
     suspend fun getBanReport(user: LinkUser): String
     suspend fun getIdentityAccessesReport(user: LinkUser): String
 }
@@ -29,7 +29,7 @@ internal class LinkGdprReportImpl : LinkGdprReport, KoinComponent {
     private val privacy: LinkPrivacy by inject()
     private val env: LinkServerEnvironment by inject()
 
-    override suspend fun getFullReport(user: LinkUser): String =
+    override suspend fun getFullReport(user: LinkUser, requester: String): String =
         """
         |# ${env.name} GDPR report for user ${user.discordId}
         |
@@ -39,7 +39,7 @@ internal class LinkGdprReportImpl : LinkGdprReport, KoinComponent {
         |
         |${getUserInfoReport(user)}
         |
-        |${getTrueIdentityReport(user)}
+        |${getTrueIdentityReport(user, requester)}
         |
         |${getBanReport(user)}
         |
@@ -66,13 +66,13 @@ internal class LinkGdprReportImpl : LinkGdprReport, KoinComponent {
         java.util.Base64.getUrlEncoder().encodeToString(this)
 
     @OptIn(UsesTrueIdentity::class) // Reports true identity, so huh, yeah
-    override suspend fun getTrueIdentityReport(user: LinkUser): String = with(user) {
+    override suspend fun getTrueIdentityReport(user: LinkUser, requester: String): String = with(user) {
         if (dbf.isUserIdentifiable(this)) {
             val identity = idManager.accessIdentity(
                 this,
-                true,
-                "EpiLink GDPR Report Service",
-                "Your identity was retrieved in order to generate a GDPR report."
+                false,
+                requester,
+                "(via EpiLink GDPR Report Service) Your identity was retrieved in order to generate a GDPR report."
             )
             """
             ## Identity information

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkIdManager.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkIdManager.kt
@@ -22,8 +22,6 @@ import org.epilink.bot.http.data.IdAccessLogs
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.slf4j.LoggerFactory
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 
 /**
  * Component that implements ID accessing logic
@@ -135,11 +133,3 @@ internal class LinkIdManagerImpl : LinkIdManager, KoinComponent {
         facade.eraseIdentity(user)
     }
 }
-
-/**
- * Utility function for hashing a String using the SHA-256 algorithm. The String is first converted to a byte array
- * using the UTF-8 charset.
- */
-// TODO replace by common util func
-private fun String.hashSha256(): ByteArray =
-    MessageDigest.getInstance("SHA-256").digest(this.toByteArray(StandardCharsets.UTF_8))

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkPermissionChecks.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkPermissionChecks.kt
@@ -13,9 +13,10 @@ import org.epilink.bot.rulebook.Rulebook
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.slf4j.LoggerFactory
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 
+/**
+ * Component for checking permissions (e.g. is a discord user allowed to create an account)
+ */
 interface LinkPermissionChecks {
     /**
      * Checks whether an account with the given Discord user ID would be allowed to create an account.
@@ -73,11 +74,3 @@ internal class LinkPermissionChecksImpl : LinkPermissionChecks, KoinComponent {
         return Allowed
     }
 }
-
-/**
- * Utility function for hashing a String using the SHA-256 algorithm. The String is first converted to a byte array
- * using the UTF-8 charset.
- */
-// TODO replace by common util func
-private fun String.hashSha256(): ByteArray =
-    MessageDigest.getInstance("SHA-256").digest(this.toByteArray(StandardCharsets.UTF_8))

--- a/bot/src/main/kotlin/org/epilink/bot/db/LinkUserCreator.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/LinkUserCreator.kt
@@ -15,10 +15,11 @@ import org.epilink.bot.infoOrDebug
 import org.koin.core.KoinComponent
 import org.koin.core.inject
 import org.slf4j.LoggerFactory
-import java.nio.charset.StandardCharsets
-import java.security.MessageDigest
 import java.time.Instant
 
+/**
+ * Component for creating a user.
+ */
 interface LinkUserCreator {
     /**
      * Create a user in the database with all of the given parameters
@@ -78,11 +79,3 @@ private inline infix fun DatabaseAdvisory.and(lazyOther: () -> DatabaseAdvisory)
         is Disallowed -> this
         Allowed -> lazyOther()
     }
-
-/**
- * Utility function for hashing a String using the SHA-256 algorithm. The String is first converted to a byte array
- * using the UTF-8 charset.
- */
-// TODO replace by common util func
-private fun String.hashSha256(): ByteArray =
-    MessageDigest.getInstance("SHA-256").digest(this.toByteArray(StandardCharsets.UTF_8))

--- a/bot/src/main/kotlin/org/epilink/bot/db/Utils.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/Utils.kt
@@ -1,0 +1,11 @@
+package org.epilink.bot.db
+
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * Utility function for hashing a String using the SHA-256 algorithm. The String is first converted to a byte array
+ * using the UTF-8 charset.
+ */
+fun String.hashSha256(): ByteArray =
+    MessageDigest.getInstance("SHA-256").digest(this.toByteArray(StandardCharsets.UTF_8))

--- a/bot/src/main/kotlin/org/epilink/bot/db/Utils.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/db/Utils.kt
@@ -1,3 +1,11 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
 package org.epilink.bot.db
 
 import java.nio.charset.StandardCharsets

--- a/bot/src/main/kotlin/org/epilink/bot/http/LinkSessionChecks.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/LinkSessionChecks.kt
@@ -111,9 +111,17 @@ internal class LinkSessionChecksImpl : LinkSessionChecks, KoinComponent {
 }
 
 internal val userObjAttribute = AttributeKey<LinkUser>("EpiLinkUserObject")
+
+/**
+ * Retrieve the user. You must have previously called [LinkSessionChecks.verifyUser] in the pipeline.
+ */
 val ApplicationCall.user: LinkUser
     get() = this.attributes[userObjAttribute]
 
 internal val adminObjAttribute = AttributeKey<LinkUser>("EpiLinkAdminObject")
+
+/**
+ * Retrieve the admin. You must have previously called [LinkSessionChecks.verifyAdmin] in the pipeline.
+ */
 val ApplicationCall.admin: LinkUser
     get() = this.attributes[adminObjAttribute]

--- a/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkAdminApi.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkAdminApi.kt
@@ -21,7 +21,6 @@ import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.routing.post
 import io.ktor.routing.route
-import org.epilink.bot.StandardErrorCodes
 import org.epilink.bot.StandardErrorCodes.*
 import org.epilink.bot.db.*
 import org.epilink.bot.discord.LinkBanManager
@@ -192,9 +191,7 @@ internal class LinkAdminApiImpl : LinkAdminApi, KoinComponent {
                     "Your identity was retrieved for logging purposes because you requested a GDPR report on someone."
                 )
                 val report = gdprReport.getFullReport(target, adminId)
-                call.respond(
-                    TextContent(report, ContentType.parse("text/markdown"), OK)
-                ) // TODO move the parse out of here
+                call.respond(TextContent(report, ContentType.Text.Markdown, OK))
             }
         }
     }
@@ -205,3 +202,12 @@ internal class LinkAdminApiImpl : LinkAdminApi, KoinComponent {
     private fun ByteArray.encodeUrlSafeBase64() =
         Base64.getUrlEncoder().encodeToString(this)
 }
+
+private val markdownContentType = ContentType("text", "markdown")
+
+/**
+ * Markdown (text/markdown) content type
+ */
+@Suppress("unused")
+val ContentType.Text.Markdown: ContentType
+    get() = markdownContentType

--- a/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkAdminApi.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkAdminApi.kt
@@ -178,13 +178,20 @@ internal class LinkAdminApiImpl : LinkAdminApi, KoinComponent {
             }
         }
 
+        @OptIn(UsesTrueIdentity::class)
         get("gdprreport/{targetId}") {
             val targetId = call.parameters["targetId"]!!
             val target = dbf.getUser(targetId)
             if (target == null) {
                 call.respond(NotFound, TargetUserDoesNotExist.toResponse())
             } else {
-                val report = gdprReport.getFullReport(target)
+                val adminId = idManager.accessIdentity(
+                    call.admin,
+                    true,
+                    "EpiLink Admin Service",
+                    "Your identity was retrieved for logging purposes because you requested a GDPR report on someone."
+                )
+                val report = gdprReport.getFullReport(target, adminId)
                 call.respond(
                     TextContent(report, ContentType.parse("text/markdown"), OK)
                 ) // TODO move the parse out of here

--- a/bot/src/test/kotlin/org/epilink/bot/AdminTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/AdminTest.kt
@@ -460,6 +460,7 @@ class AdminTest : KoinBaseTest(
         }
     }
 
+    @OptIn(UsesTrueIdentity::class)
     @Test
     fun `Test generating a GDPR report`() {
         declare(named("admins")) { listOf("adminid") }
@@ -467,8 +468,13 @@ class AdminTest : KoinBaseTest(
         mockHere<LinkDatabaseFacade> {
             coEvery { getUser("userid") } returns u
         }
+        mockHere<LinkIdManager> {
+            coEvery {
+                accessIdentity(match { it.discordId == "adminid" }, true, any(), any())
+            } returns "admin@admin.admin"
+        }
         mockHere<LinkGdprReport> {
-            coEvery { getFullReport(u) } returns "C'est la merguez, merguez partie !"
+            coEvery { getFullReport(u, "admin@admin.admin") } returns "C'est la merguez, merguez partie !"
         }
         withTestEpiLink {
             val sid = setupSession(sessionStorage, "adminid")

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -654,3 +654,17 @@ The request body is a [BanRequest](#banrequest) object.
 Should the ban request have an invalid expiry date, the request is ignored and an HTTP 400 error with [error code 404](#4xx-codes) is returned.
 
 Returns the newly created ban as a [BanInfo](#baninfo) object.
+
+### GET /admin/gdprreport/{targetId}
+
+**Generate a GDPR report about the target.**
+
+```http request
+GET /admin/ban/{targetId}
+```
+
+Where `targetId` is the Discord ID of the person you want to generate a GDPR report about.
+
+> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML directly. `Content-Type: text/markdown`
+
+Returns the report directly as a Markdown document. May also return an API error in case the Discord ID is invalid. Generates an ID access request (which is included in the report) in order to add the user's identity in the report.

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -665,6 +665,6 @@ GET /admin/ban/{targetId}
 
 Where `targetId` is the Discord ID of the person you want to generate a GDPR report about.
 
-> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML directly. `Content-Type: text/markdown`
+> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns a Markdown document directly. `Content-Type: text/markdown`
 
 Returns the report directly as a Markdown document. May also return an API error in case the Discord ID is invalid. Generates an ID access request (which is included in the report) in order to add the user's identity in the report.

--- a/docs/MaintainerGuide.md
+++ b/docs/MaintainerGuide.md
@@ -6,7 +6,7 @@ This page will guide you through the configuration of a working EpiLink instance
 
 Go through all of these steps before going public:
 
-- Get EpiLink (and all of the [required stuff](#deployment-methods))
+- Get EpiLink (and all of the [required stuff](#deployment))
 - [Configure it](#configuration) using the [sample configuration](https://github.com/EpiLink/EpiLink/tree/master/bot/config/epilink_config.yaml) as a template
 - Make sure everything works
 - Place EpiLink behind a reverse proxy and enable HTTPS through your reverse proxy
@@ -371,6 +371,7 @@ Here is what you can do using the administrative actions provided by EpiLink:
 - [Get information about a user](Api.md#get-adminuseruserid)
 - [Get a user's true identity](Api.md#post-adminidrequest)
 - [Ban a user](Api.md#post-adminbanmsfthash), [get previous bans](Api.md#get-adminbanmsfthash) and [revoke them](Api.md#post-adminbanmsfthashbanidrevoke)
+- [Generate a GDPR report about a user](Api.md#get-admingdprreporttargetid)
 
 !> **No front-end is provided for administrative actions.** We recommend that you get your `SessionId` from your browser and use the APIs manually. They are very simple to use. Also, note that all of what you see in the API page requires a `/api/v1` before the actual path, e.g. `/api/v1/admin/user/...` instead of just `/admin/user/...`.
 
@@ -389,3 +390,7 @@ Bans are simple: a banned user will not get any role from EpiLink. That's all!
 **Any ID access done through the API may lead to a notification on the user's side**, depending on your [privacy configuration](#privacy-configuration).
 
 An ID access allows you to get a user's identity while also notifying them for more transparency. Note that while you can disable the ID access notifications (i.e. the Discord DMs), the users will always see every ID access from their profile page.
+
+### GDPR Report
+
+You can generate a GDPR report using [the `/admin/gdprreport/{discordid}` endpoint](Api.md#get-admingdprreporttargetid). Note that these reports also include the identity of the person, and thus generate a manual identity access report.


### PR DESCRIPTION
## Description

Adds an automatic report generator + an admin endpoint to use it.

#### Related issue(s)

Partially addresses #7 

<!-- Replace the [ ] by [X] to tick boxes -->
<!-- Remove any item which does not apply to this PR -->
### TODO

* [x] The ID access should be reported as manual, requester should be the requesting admin, request reason should clarify that this is a GDPR request.
* [x] Code cleanup + KDoc
* [x] Update the docs with the changes that have been made (add info on how to use the endpoint in the maintainer guide)
* [x] Update `CHANGELOG.md`
