### PR TITLE
Allow using PDF in tos/policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+* Added PDF support for ToS and Privacy Policy documents ([#175](https://github.com/EpiLink/EpiLink/pull/175))
 * Added GDPR report generation ([#173](https://github.com/EpiLink/EpiLink/pull/173))
 * Added ban notifications ([#168](https://github.com/EpiLink/EpiLink/pull/168))
 * Added administration endpoints (and its documentation) ([#161](https://github.com/EpiLink/EpiLink/pull/161))
@@ -29,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+* Fixed the ToS being served on both ToS and PP pages ([#175](https://github.com/EpiLink/EpiLink/pull/175))
 * Reduced the amount of calls to `getUser`, resulting in better performance with fewer calls to the DB ([#165](https://github.com/EpiLink/EpiLink/pull/165)).
 * Re-added the server(s) name(s) in the "could not authenticate you" Discord embed ([#161](https://github.com/EpiLink/EpiLink/pull/161))
 * Fixed an extra newline in an embed ([#161](https://github.com/EpiLink/EpiLink/pull/161))

--- a/bot/src/main/kotlin/org/epilink/bot/LinkLegalTexts.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/LinkLegalTexts.kt
@@ -8,6 +8,8 @@
  */
 package org.epilink.bot
 
+import io.ktor.http.ContentType
+import io.ktor.util.extension
 import org.epilink.bot.config.LinkLegalConfiguration
 import java.nio.file.Files
 import java.nio.file.Path
@@ -19,29 +21,59 @@ data class LinkLegalTexts(
     /**
      * The terms of services' text
      */
-    val tosText: String,
+    val termsOfServices: LegalText,
     /**
      * The privacy policy's text
      */
-    val policyText: String,
+    val privacyPolicy: LegalText,
     /**
      * The text shown in the ID prompt ("Remember who I am").
      */
     val idPrompt: String
 )
 
+private val defaultTosText =
+    """
+    <strong>No Terms of Services found.</strong> Please contact your administrator for more information.
+    """.trimIndent()
+
+private val defaultPpText =
+    """
+    <strong>No Privacy Policy found.</strong> Please contact your administrator for more information.
+    """.trimIndent()
+
+private val defaultIdPromptText =
+    """
+    <p class="description">For more information, contact your administrator or consult the privacy policy.</p>
+    """.trimIndent()
+
+
 /**
  * Load the legal texts from the given configuration files
  */
 fun LinkLegalConfiguration.load(cfg: Path): LinkLegalTexts {
     return LinkLegalTexts(
-        tosText = tos ?: tosFile?.let { Files.readString(cfg.resolveSibling(it)) } ?: """
-            <strong>No Terms of Services found.</strong> Please contact your administrator for more information.
-            """.trimIndent(),
-        policyText = policy ?: policyFile?.let { Files.readString(cfg.resolveSibling(it)) } ?: """
-            <strong>No Privacy Policy found.</strong> Please contact your administrator for more information.
-            """.trimIndent(),
-        idPrompt = identityPromptText
-            ?: "<p class=\"description\">For more information, contact your administrator or consult the privacy policy.</p>"
+        termsOfServices = loadLegalText(tos, tosFile?.let { { cfg.resolveSibling(it) } }, defaultTosText),
+        privacyPolicy = loadLegalText(policy, policyFile?.let { { cfg.resolveSibling(it) } }, defaultPpText),
+        idPrompt = identityPromptText ?: defaultIdPromptText
     )
+}
+
+sealed class LegalText(val contentType: ContentType) {
+    data class Html(val text: String) : LegalText(ContentType.Text.Html)
+    class Pdf(val data: ByteArray) : LegalText(ContentType.Application.Pdf)
+}
+
+
+fun loadLegalText(textValue: String?, file: (() -> Path)?, defaultText: String): LegalText {
+    return when {
+        textValue != null -> LegalText.Html(textValue)
+        file != null -> file().let {
+            if (it.extension == "pdf")
+                LegalText.Pdf(Files.readAllBytes(it))
+            else
+                LegalText.Html(Files.readString(it))
+        }
+        else -> LegalText.Html(defaultText)
+    }
 }

--- a/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkMetaApi.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/http/endpoints/LinkMetaApi.kt
@@ -12,11 +12,15 @@ import guru.zoroark.ratelimit.rateLimited
 import io.ktor.application.call
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.OK
+import io.ktor.http.content.ByteArrayContent
+import io.ktor.http.content.OutgoingContent
 import io.ktor.http.content.TextContent
 import io.ktor.response.respond
 import io.ktor.routing.Route
 import io.ktor.routing.get
 import io.ktor.routing.route
+import org.epilink.bot.LegalText
 import org.epilink.bot.LinkLegalTexts
 import org.epilink.bot.LinkServerEnvironment
 import org.epilink.bot.config.LinkWebServerConfiguration
@@ -67,12 +71,12 @@ internal class LinkMetaApiImpl : LinkMetaApi, KoinComponent {
 
                 @ApiEndpoint("GET /api/v1/meta/tos")
                 get("tos") {
-                    call.respond(HttpStatusCode.OK, TextContent(legal.tosText, ContentType.Text.Html))
+                    call.respond(legal.termsOfServices.asResponseContent())
                 }
 
                 @ApiEndpoint("GET /api/v1/meta/privacy")
                 get("privacy") {
-                    call.respond(HttpStatusCode.OK, TextContent(legal.policyText, ContentType.Text.Html))
+                    call.respond(legal.privacyPolicy.asResponseContent())
                 }
             }
         }
@@ -92,3 +96,9 @@ internal class LinkMetaApiImpl : LinkMetaApi, KoinComponent {
             contacts = wsCfg.contacts
         )
 }
+
+private fun LegalText.asResponseContent(): OutgoingContent.ByteArrayContent =
+    when(this) {
+        is LegalText.Pdf -> ByteArrayContent(data, ContentType.Application.Pdf, OK)
+        is LegalText.Html -> TextContent(text, ContentType.Text.Html, OK)
+    }

--- a/bot/src/test/kotlin/org/epilink/bot/LegalTextsTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/LegalTextsTest.kt
@@ -8,117 +8,41 @@
  */
 package org.epilink.bot
 
-import io.mockk.every
-import io.mockk.mockk
-import org.epilink.bot.config.LinkLegalConfiguration
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertSame
+import kotlin.test.assertTrue
 
 class LegalTextsTest {
     private val pfolder = Files.createTempDirectory("epilink-tests-legal")
-    private val fakeCfg = pfolder.resolve("hello.yaml").apply { Files.createFile(this) }
 
     @Test
-    fun `Test ToS as string`() {
-        val str = "Terms of servicesss"
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { tos } returns str
-            // Default behavior for other things
-            every { policyFile } returns null
-            every { policy } returns null
-            every { identityPromptText } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertSame(str, loaded.tosText)
+    fun `Test load text`() {
+        assertEquals(LegalText.Html("one"), loadLegalText("one", { error("no") }, "two"))
     }
 
     @Test
-    fun `Test ToS as file`() {
-        val str = "Terms of servicesss but in a file\nAmazing!"
+    fun `Test load HTML file`() {
+        val str = "<p>Terms of servicesss but in a file<br>Amazing!</p>"
         val fileName = "tos-file.html"
         val p = pfolder.resolve(fileName)
         Files.write(p, str.toByteArray())
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { tos } returns null
-            every { tosFile } returns "tos-file.html"
-            // Default behavior for other things
-            every { policyFile } returns null
-            every { policy } returns null
-            every { identityPromptText } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertEquals(str, loaded.tosText)
+        assertEquals(LegalText.Html(str), loadLegalText(null, { p }, "no"))
     }
 
     @Test
-    fun `Test defaults`() {
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { tos } returns null
-            every { tosFile } returns null
-            every { policyFile } returns null
-            every { policy } returns null
-            every { identityPromptText } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertEquals(
-            "<strong>No Terms of Services found.</strong> Please contact your administrator for more information.",
-            loaded.tosText
-        )
-        assertEquals(
-            "<strong>No Privacy Policy found.</strong> Please contact your administrator for more information.",
-            loaded.policyText
-        )
-        assertEquals(
-            "<p class=\"description\">For more information, contact your administrator or consult the privacy policy.</p>",
-            loaded.idPrompt
-        )
+    fun `Test load PDF file`() {
+        val data = byteArrayOf(1, 2, 3, 4)
+        val filename = "no.pdf"
+        val p = pfolder.resolve(filename)
+        Files.write(p, data)
+        val result = loadLegalText(null, { p }, "no")
+        assertTrue(result is LegalText.Pdf)
+        assertTrue(data.contentEquals(result.data))
     }
 
     @Test
-    fun `Test PP as string`() {
-        val str = "Privacy policyyyy"
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { policy } returns str
-            // Default behavior for other things
-            every { tos } returns null
-            every { tosFile } returns null
-            every { identityPromptText } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertSame(str, loaded.policyText)
-    }
-
-    @Test
-    fun `Test PP as file`() {
-        val str = "Privacy policy, in a \nfiiiiiile"
-        val fileName = "pp-file.html"
-        val p = pfolder.resolve(fileName)
-        Files.write(p, str.toByteArray())
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { policy } returns null
-            every { policyFile } returns fileName
-            // Default behavior for other things
-            every { tos } returns null
-            every { tosFile } returns null
-            every { identityPromptText } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertEquals(str, loaded.policyText)
-    }
-
-    @Test
-    fun `Test ID prompt is passed as is`() {
-        val hello = "helloooooooooo"
-        val cfg = mockk<LinkLegalConfiguration> {
-            every { identityPromptText } returns hello
-            every { tos } returns null
-            every { tosFile } returns null
-            every { policyFile } returns null
-            every { policy } returns null
-        }
-        val loaded = cfg.load(fakeCfg)
-        assertSame(hello, loaded.idPrompt)
+    fun `Test default value`() {
+        assertEquals(LegalText.Html("three"), loadLegalText(null, null, "three"))
     }
 }

--- a/docs/Api.md
+++ b/docs/Api.md
@@ -182,14 +182,16 @@ Returns information about this instance, as a [InstanceInformation](#instanceinf
 GET /api/v1/meta/tos
 ```
 
-> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML directly. `Content-Type: text/html`
+> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML or a PDF file directly. `Content-Type: text/html` or `Content-Type: application/pdf`
 
-Returns the terms of services of this instance, as inline HTML.
+Returns the terms of services of this instance, as inline HTML or as a PDF.
 
 Example:
 ```html
 <p>My terms of services are the best terms of services!</p>
 ```
+
+(or a PDF file's contents)
 
 ### GET /meta/privacy
 
@@ -199,14 +201,16 @@ Example:
 GET /api/v1/meta/privacy
 ```
 
-> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML directly. `Content-Type: text/html`
+> **DOES NOT RETURN AN API RESPONSE.** This endpoint returns inline HTML directly or a PDF file. `Content-Type: text/html` or `Content-Type: application/pdf`
 
-Returns the privacy policy of this instance, as inline HTML.
+Returns the privacy policy of this instance, as inline HTML or as a PDF.
 
 Example:
 ```html
 <p>My privacy policy is very private!</p>
 ```
+
+(or a PDF file's contents)
 
 ## Registration (/register)
 

--- a/docs/MaintainerGuide.md
+++ b/docs/MaintainerGuide.md
@@ -350,10 +350,10 @@ legal:
 
 This section provides the legal documents EpiLink will show to the users. More specifically, this section contains the terms of services, the privacy policy (both either as a string or as a path to the file) and the identity prompt text.
 
-All three options **are HTML**. Use them to format your text with lists and other things. They are not full HTML documents, rather just HTML fragments that will be thrown in the front-end.
+All three options **are HTML**, but files also support PDFs. Use them to format your text with lists and other things. Any HTML content is not a full HTML document, rather just HTML fragments that will be thrown in the front-end. PDF files will be served as-is to the front-end, with an additional download link.
 
-* `tos`/`tosFile`: The terms of services, either directly written in the config file (`tos`), or as a path relative to the configuration file's location (`tosFile`)
-* `policy`/`policyFile`: The privacy policy, either directly written in the config file (`policy`), or as a path relative to the configuration file's location (`policyFile`)
+* `tos`/`tosFile`: The terms of services, either directly written in the config file (`tos`), or as a path relative to the configuration file's location (`tosFile`). `tos` is inline HTML, `tosFile` can be either a file containing inline HMTL or a PDF file.
+* `policy`/`policyFile`: The privacy policy, either directly written in the config file (`policy`), or as a path relative to the configuration file's location (`policyFile`). `policy` is inline HTML, `policyFile` can be either a file containing inline HMTL or a PDF file.
 * `identityPromptText`: The text that is shown below the "Remember who I am" checkbox in the registration page. This should describe in a few words what the user should expect to happen if they check (or uncheck) the box. You can also put "See the privacy policy for more details". This is also HTML.
 
 All options are optional, but you should fill them in regardless. Not filling them in results in a warning in the start-up logs. Filling both an in-config option *and* its file-based counterpart will result in an error, similar to `rulebook`/`rulebookFile`.

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -48,10 +48,11 @@ export function isPermanentSession() {
  * @param method (optional) The request method (GET, POST, or DELETE)
  * @param path The request path, without /api/v1, starting with a slash (example '/meta/info')
  * @param body (optional) The request body object that will be encoded in JSON
+ * @param returnRawResponse (optional) True if the raw response should be returned instead of the returned JSON object.
  *
  * @returns {Promise<Object>} A Promise that resolves with the request result data, or fails with the request error message
  */
-export default async function(method, path, body) {
+export default async function(method, path, body, returnRawResponse = false) {
     if (!body && typeof path !== 'string') {
         // [path, body?]
         body = path;
@@ -77,6 +78,9 @@ export default async function(method, path, body) {
     }
 
     const result = await fetch(BACKEND_URL + path, params);
+    if (returnRawResponse) {
+        return result;
+    }
     const text = await result.text();
     if (!text) {
         console.warn(`API returned an empty response during request '${method} ${path}'`);

--- a/web/src/i18n/en.js
+++ b/web/src/i18n/en.js
@@ -99,5 +99,9 @@ export default {
         discord: 'Connection to Discord',
         microsoft: 'Connection to Microsoft',
         settings: 'Settings review'
+    },
+
+    meta: {
+        downloadPdf: 'Download this PDF file'
     }
 };

--- a/web/src/i18n/fr.js
+++ b/web/src/i18n/fr.js
@@ -99,5 +99,9 @@ export default {
         discord: 'Connexion à Discord',
         microsoft: 'Connexion à Microsoft',
         settings: 'Validation des paramètres'
+    },
+
+    meta: {
+        downloadPdf: 'Télécharger ce fichier PDF'
     }
 };

--- a/web/src/store/texts.js
+++ b/web/src/store/texts.js
@@ -26,24 +26,28 @@ export default {
         }
     },
     actions: {
-        async fetchTermsOfService({ state, commit }) {
+        async fetchTermsOfService({ state, commit, dispatch }) {
             if (state.termsOfService) {
                 return;
             }
-
-            const req = await request('GET', '/meta/tos', null, true);
-            const isPdf = req.headers.get('Content-Type') === 'application/pdf';
-            commit('setTermsOfService', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? URL.createObjectURL(await req.blob()) : null, 'url': req.url});
+            commit('setTermsOfService', await dispatch('fetchText', 'tos'));
         },
 
-        async fetchPrivacyPolicy({ state, commit }) {
+        async fetchPrivacyPolicy({ state, commit, dispatch }) {
             if (state.privacyPolicy) {
                 return;
             }
+            commit('setPrivacyPolicy', await dispatch('fetchText', 'privacy'));
+        },
 
-            const req = await request('GET', '/meta/privacy', null, true);
+        async fetchText(_, requestUrl) {
+            const req = await request('GET', `/meta/${requestUrl}`, null, true);
             const isPdf = req.headers.get('Content-Type') === 'application/pdf';
-            commit('setPrivacyPolicy', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? URL.createObjectURL(await req.blob()) : null, 'url': req.url});
+            return {
+                textContent: !isPdf && await req.text(),
+                pdfContent: isPdf && URL.createObjectURL(await req.blob()),
+                url: req.url
+            };
         }
     }
 };

--- a/web/src/store/texts.js
+++ b/web/src/store/texts.js
@@ -31,7 +31,9 @@ export default {
                 return;
             }
 
-            commit('setTermsOfService', await request('/meta/tos'));
+            const req = await request('GET', '/meta/tos', null, true);
+            const isPdf = req.headers.get('Content-Type') === 'application/pdf';
+            commit('setTermsOfService', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? URL.createObjectURL(await req.blob()) : null, 'url': req.url});
         },
 
         async fetchPrivacyPolicy({ state, commit }) {
@@ -39,7 +41,9 @@ export default {
                 return;
             }
 
-            commit('setPrivacyPolicy', await request('/meta/privacy'));
+            const req = await request('GET', '/meta/privacy', null, true);
+            const isPdf = req.headers.get('Content-Type') === 'application/pdf';
+            commit('setPrivacyPolicy', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? await req.blob() : null, 'url': req.url});
         }
     }
 };

--- a/web/src/store/texts.js
+++ b/web/src/store/texts.js
@@ -43,7 +43,7 @@ export default {
 
             const req = await request('GET', '/meta/privacy', null, true);
             const isPdf = req.headers.get('Content-Type') === 'application/pdf';
-            commit('setPrivacyPolicy', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? await req.blob() : null, 'url': req.url});
+            commit('setPrivacyPolicy', {'textContent': isPdf ? null : await req.text(), 'pdfContent': isPdf ? URL.createObjectURL(await req.blob()) : null, 'url': req.url});
         }
     }
 };

--- a/web/src/views/MetaText.vue
+++ b/web/src/views/MetaText.vue
@@ -16,12 +16,16 @@
         </h1>
         <a class="back" @click="$router.back()" v-html="$t('back')" />
 
-        <div class="text-content">
-            <transition name="fade" mode="out-in">
-                <link-loading v-if="!content" :key="0" />
-                <p class="text" v-if="content" v-html="content" :key="2" />
-            </transition>
-        </div>
+        <transition name="fade" mode="out-in">
+            <link-loading v-if="!content" :key="0" />
+            <div class="text-content" v-if="content && contentText" :key="2">
+                <p class="text" v-html="contentText"/>
+            </div>
+            <div class="pdf-things" v-if="content && contentPdf" :key="2">
+                <p><a :href="contentPdf" v-html="$t('meta.downloadPdf')">Download this PDF file</a></p>
+                <iframe :src="contentPdf"></iframe>
+            </div>
+        </transition>
     </div>
 </template>
 
@@ -50,9 +54,18 @@
             }
         },
         computed: {
+            isPrivacyPolicy() {
+                return this.$route.name === 'privacy';
+            },
             content() {
                 const prop = this.isPrivacyPolicy ? 'privacyPolicy' : 'termsOfService';
                 return this.$store.state.texts[prop];
+            },
+            contentText() {
+                return this.content.textContent;
+            },
+            contentPdf() {
+                return this.content.pdfContent;
             }
         }
     }
@@ -104,6 +117,24 @@
 
         .text {
             text-align: center;
+        }
+    }
+
+    .pdf-things {
+        display: flex;
+        flex-direction: column;
+        min-width: 100%;
+        height: 100%;
+
+        p {
+            text-align: center;
+        }
+        a {
+            text-decoration: underline;
+        }
+        iframe {
+            width: 100%;
+            flex-grow: 1;
         }
     }
 </style>

--- a/web/src/views/MetaText.vue
+++ b/web/src/views/MetaText.vue
@@ -22,7 +22,7 @@
                 <p class="text" v-html="contentText"/>
             </div>
             <div class="pdf-things" v-if="content && contentPdf" :key="2">
-                <p><a :href="contentPdf" v-html="$t('meta.downloadPdf')">Download this PDF file</a></p>
+                <p><a :href="contentPdf" v-html="$t('meta.downloadPdf')" target="_blank"></a></p>
                 <iframe :src="contentPdf"></iframe>
             </div>
         </transition>


### PR DESCRIPTION
<!-- Describe your pull request here -->
### Description

This PR will (eventually (in the near future (probably))) allow using PDF files as ToS and privacy policy sources.

- On the back-end, simply serve either HTML or PDF files at the ToS and Privacy Policy endpoints (`/meta/tos` and `/meta/privacy`)
- On the front-end, properly show the PDF file while still keeping the current behavior if we received HTML content.
- Also fixed the front-end serving the ToS in the PP tab

#### Related issue(s)

I don't think we had an issue open for this

<!-- Replace the [ ] by [X] to tick boxes -->
<!-- Remove any item which does not apply to this PR -->
### TODO

* [x] Back-end implementation
* [x] Front-end implementation
* [x] Update the docs with the changes that have been made
* [x] Update `CHANGELOG.md`
