### PR TITLE
Fixed Docker image SSL + Netlify deployement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,46 +33,12 @@ RUN jlink \
       --output /tmp/epilink-jvm
 
 
-# Reseting the image build with GLibC (required by Java) Alpine
-FROM alpine:3.11
+# Reseting the image build with a JLink-prepared Alpine Linux
+FROM litarvan/alpine-jlink:3.12
 
 ENV USER epilink
 ENV LINK_ROOT /var/run/epilink
 ENV JAVA_HOME $LINK_ROOT/jvm
-
-# Setting up Java dependencies, taken from AdoptOpenJDK/openjdk-docker 
-ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-RUN apk add --no-cache --virtual .build-deps curl binutils \
-    && GLIBC_VER="2.31-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-9.1.0-2-x86_64.pkg.tar.xz" \
-    && GCC_LIBS_SHA256="91dba90f3c20d32fcf7f1dbe91523653018aa0b8d2230b00f822f6722804cf08" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.xz \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && tar -xf /tmp/gcc-libs.tar.xz -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar.xz /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
 # Creating the runner user
 RUN addgroup -g 1000 $USER && adduser -u 1000 -D -G $USER $USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN jlink \
 
 
 # Reseting the image build with a JLink-prepared Alpine Linux
+# See https://github.com/Litarvan/docker-jlink-alpine
 FROM litarvan/alpine-jlink:3.12
 
 ENV USER epilink

--- a/bot/docker_run.sh
+++ b/bot/docker_run.sh
@@ -20,4 +20,4 @@ fi
 
 echo
 
-bin/epilink-backend $ARGS $CONFIG_PATH
+EPILINK_BACKEND_OPTS=-Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 $EPILINK_BACKEND_OPTS bin/epilink-backend $ARGS $CONFIG_PATH

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "serve": "vue-cli-service serve",
-    "prod": "vue-cli-service build"
+    "prod": "vue-cli-service build",
+    "prod-netlify": "vue-cli-service build --dest ./prod",
   },
   "dependencies": {
     "core-js": "^3.6.5",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "prod": "vue-cli-service build",
-    "prod-netlify": "vue-cli-service build --dest ./prod",
+    "prod-netlify": "vue-cli-service build --dest ./prod"
   },
   "dependencies": {
     "core-js": "^3.6.5",


### PR DESCRIPTION
# Description

On the Docker image, the service would always crash during Discord OAuth process because of a wrong TLS implementation. This PR fixes the issue.

To prevent merge conflicts in the changelog, I'm waiting for the 0.3 to be released before editing it.

Also, I fixed the Netlify deployement by building to a directory inside the web/ folder.

### TODO

* [ ] Update `CHANGELOG.md`
