### PR TITLE
Dockerfile: Removed JLink because too unstable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,25 +21,12 @@ RUN tar xf $BUILD_ROOT/bot/build/distributions/epilink-backend-*.tar
 RUN mkdir -p /tmp/epilink-final
 RUN mv epilink-backend-*/* /tmp/epilink-final
 
-# Installing binutils (required by jlink)
-RUN apk --no-cache add binutils
-
-# Exporting our JVM
-RUN jlink \
-      --no-header-files --no-man-pages \
-      --compress=2 \
-      --strip-debug \
-      --add-modules java.base,java.desktop,java.logging,java.sql,java.naming,java.security.jgss,java.xml,java.management,java.scripting,java.compiler,java.rmi,jdk.unsupported \
-      --output /tmp/epilink-jvm
-
 
 # Reseting the image build with a JLink-prepared Alpine Linux
-# See https://github.com/Litarvan/docker-jlink-alpine
-FROM litarvan/alpine-jlink:3.12
+FROM adoptopenjdk/openjdk13:alpine-jre
 
 ENV USER epilink
 ENV LINK_ROOT /var/run/epilink
-ENV JAVA_HOME $LINK_ROOT/jvm
 
 # Creating the runner user
 RUN addgroup -g 1000 $USER && adduser -u 1000 -D -G $USER $USER
@@ -54,7 +41,6 @@ USER $USER
 
 # Copying files from BUILDER step
 COPY --from=BUILDER /tmp/epilink-final ./
-COPY --from=BUILDER /tmp/epilink-jvm $JAVA_HOME
 
 # Copying run script
 COPY bot/docker_run.sh ./run
@@ -62,3 +48,4 @@ COPY bot/docker_run.sh ./run
 # Final settings
 EXPOSE 9090
 CMD ["/bin/sh", "./run"]
+

--- a/bot/docker_run.sh
+++ b/bot/docker_run.sh
@@ -20,4 +20,4 @@ fi
 
 echo
 
-EPILINK_BACKEND_OPTS=-Djdk.tls.client.protocols=TLSv1,TLSv1.1,TLSv1.2 $EPILINK_BACKEND_OPTS bin/epilink-backend $ARGS $CONFIG_PATH
+bin/epilink-backend $ARGS $CONFIG_PATH


### PR DESCRIPTION
### Description 

Removed JLink on the Docker image because it caused too many crashes due to the SSL implementation.
