### PR TITLE
Safari popup error hotfix

### DIFF
--- a/web/src/views/Redirect.vue
+++ b/web/src/views/Redirect.vue
@@ -56,7 +56,7 @@
                     return;
                 }
 
-                window.opener.postMessage({ code });
+                window.opener.postMessage({ code }, window.origin);
                 window.close();
             }, 1250);
         },


### PR DESCRIPTION
# Description

Hotfixes the Safari popup error resulting in an unusable linking process.