### PR TITLE
Implement the _notIdentified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Added
 
 * Added I18n support on the back-end, including Discord I18n with the `e!lang` command. ([#204](https://github.com/EpiLink/EpiLink/pull/204))
+* Added the `_notIdentified` EpiLink role. You can now attribute roles to users who are registered but do not have their identity stored in the database. ([#211](https://github.com/EpiLink/EpiLink/pull/211))
 
 ### Changed
 

--- a/bot/src/main/kotlin/org/epilink/bot/discord/LinkRoleManager.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/discord/LinkRoleManager.kt
@@ -304,9 +304,13 @@ internal class LinkRoleManagerImpl : LinkRoleManager, KoinComponent {
 
     // Computes the base set is the set of standard EpiLink roles (_known, _identified)
     private fun getBaseRoleSetForKnown(identifiable: Boolean): Set<String> =
-        mutableSetOf(StandardRoles.Known.roleName).apply {
-            if (identifiable) add(StandardRoles.Identified.roleName)
-        }
+        mutableSetOf(
+            StandardRoles.Known.roleName,
+            if (identifiable)
+                StandardRoles.Identified.roleName
+            else
+                StandardRoles.NotIdentified.roleName
+        )
 
     @UsesTrueIdentity
     private suspend fun roleUpdateIdAccess(

--- a/bot/src/main/kotlin/org/epilink/bot/discord/StandardRoles.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/discord/StandardRoles.kt
@@ -15,6 +15,11 @@ package org.epilink.bot.discord
  */
 enum class StandardRoles(val roleName: String) {
     /**
+     * A user who is authenticated but does not have their identity stored in the database.
+     */
+    NotIdentified("_notIdentified"),
+
+    /**
      * A user who has his true identity stored in the database
      */
     Identified("_identified"),

--- a/bot/src/test/kotlin/org/epilink/bot/DiscordRoleManagerTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/DiscordRoleManagerTest.kt
@@ -317,7 +317,7 @@ class DiscordRoleManagerTest : KoinBaseTest(
         val rm = get<LinkRoleManager>()
         runBlocking {
             val roles = rm.getRolesForUser("userid", listOf(), true, listOf())
-            assertEquals(setOf("_known"), roles)
+            assertEquals(setOf("_known", "_notIdentified"), roles)
         }
     }
 
@@ -428,7 +428,7 @@ class DiscordRoleManagerTest : KoinBaseTest(
                 true,
                 listOf()
             )
-            assertEquals(setOf("_known", "wirId_userid", "wirDisc_disc"), roles)
+            assertEquals(setOf("_known", "_notIdentified", "wirId_userid", "wirDisc_disc"), roles)
         }
     }
 

--- a/docs/MaintainerGuide.md
+++ b/docs/MaintainerGuide.md
@@ -282,6 +282,7 @@ The EpiLink role names that begin with a `_` are roles that EpiLink determines a
 
 * `_known`: The user has an account at EpiLink, is not banned and is authenticated. Use this role when you need to know that the user is part of the organization.
 * `_identified`: The user is `_known` and also has his true identity kept in the system. That is, you could potentially get their e-mail address. Use this role when you need to also be able to determine who the user is at any time.
+* `_notIdentified`: The user is `_known` but does not have their true identity kept in the system (i.e. `_known` but not `_identified`).
 
 Role names that do not begin with a `_` are custom roles you define through [rules in rulebooks](Rulebooks.md).
 


### PR DESCRIPTION
<!-- Describe your pull request here -->
### Description

Implements `_notIdentified` which allows you to give roles to people who are registered but do not have their identity recorded.

<!-- Delete the following section if this PR does not address any issue -->
#### Related issue(s)

Fixes #206 

<!-- Replace the [ ] by [X] to tick boxes -->
<!-- Remove any item which does not apply to this PR -->
### TODO

* [ ] Update the docs with the changes that have been made
* [ ] Update `CHANGELOG.md`
