### PR TITLE
Fix arguments not being passed in right for Discord messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+* Fixed issues for Discord messages ([#217](https://github.com/EpiLink/EpiLink/pull/217))
 * Fixed an i18n issue on the front-end ([#216](https://github.com/EpiLink/EpiLink/pull/216)) 
 
 ## [0.5.0] - 2020-08-10

--- a/bot/src/main/kotlin/org/epilink/bot/discord/LinkDiscordMessages.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/discord/LinkDiscordMessages.kt
@@ -199,7 +199,7 @@ internal class LinkDiscordMessagesImpl : LinkDiscordMessages, KoinComponent {
     ): DiscordEmbed = language.ctx {
         DiscordEmbed(
             title = i18n["$key.title"],
-            description = i18n["$key.description"].f(objects),
+            description = i18n["$key.description"].f(*objects),
             color = errorRed,
             footer = poweredByEpiLink
         )
@@ -224,7 +224,7 @@ internal class LinkDiscordMessagesImpl : LinkDiscordMessages, KoinComponent {
         language.ctx {
             DiscordEmbed(
                 title = i18n["cr.ok.title"],
-                description = i18n[messageKey].f(messageArgs),
+                description = i18n[messageKey].f(*messageArgs),
                 color = okGreen,
                 footer = poweredByEpiLink
             )

--- a/bot/src/main/kotlin/org/epilink/bot/discord/cmd/LangCommand.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/discord/cmd/LangCommand.kt
@@ -61,7 +61,7 @@ class LangCommand : Command, KoinComponent {
             else ->
                 client.sendChannelMessage(
                     channelId,
-                    messages.getErrorCommandReply(previousLanguage, "lang.invalidLanguage")
+                    messages.getErrorCommandReply(previousLanguage, "lang.invalidLanguage", commandBody)
                 )
         }
     }

--- a/bot/src/test/kotlin/org/epilink/bot/commands/LangCommandTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/commands/LangCommandTest.kt
@@ -78,7 +78,7 @@ class LangCommandTest : KoinBaseTest(
             coEvery { getLanguage(any()) } returns ""
             coEvery { setLanguage("iid", "lll") } returns false
         }
-        mockHere<LinkDiscordMessages> { every { getErrorCommandReply(any(), "lang.invalidLanguage") } returns embed }
+        mockHere<LinkDiscordMessages> { every { getErrorCommandReply(any(), "lang.invalidLanguage", "lll") } returns embed }
         val dcf = mockHere<LinkDiscordClientFacade> { coEvery { sendChannelMessage("1234", embed) } just runs }
         test {
             run("e!lang lll", "lll", null, "iid", "1234", "")


### PR DESCRIPTION
<!-- Describe your pull request here -->
### Description

Fixes the root cause for some messages not working at all

### TODO
* [x] Update `CHANGELOG.md`
