### PR TITLE
Gradle updates: Use version catalogs & -Werror on Kotlin sources & fix dprc warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
   * Also used Gradle's `layout` feature to avoid hard-coding build paths.
   * Renamed internal classes to remove the "Link" prefix ([#289](https://github.com/EpiLink/EpiLink/pull/289))
   * Added the `detekt` tool in the build process and fixed the internal issues it found ([#299](https://github.com/EpiLink/EpiLink/pull/299))
+  * Now using Gradle's version catalog feature for dependency management ([#303](https://github.com/EpiLink/EpiLink/pull/303))
+  * Now using `-Werror` in Kotlin's compilation options ([#303](https://github.com/EpiLink/EpiLink/pull/303))
 
 ## [0.6.2] - 2021-04-14
 

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -16,12 +16,16 @@ repositories {
 
 compileKotlin {
     kotlinOptions.jvmTarget = "11"
-    kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=io.ktor.locations.KtorExperimentalLocationsAPI"]
+    kotlinOptions.freeCompilerArgs += [
+            "-Xopt-in=kotlin.RequiresOptIn",
+            "-Xopt-in=io.ktor.locations.KtorExperimentalLocationsAPI",
+            "-Werror" // All warnings as errors
+    ]
 }
 
 compileTestKotlin {
     kotlinOptions.jvmTarget = "11"
-    kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn"]
+    kotlinOptions.freeCompilerArgs += ["-Xopt-in=kotlin.RequiresOptIn", "-Werror"]
 }
 
 application {
@@ -113,5 +117,16 @@ task generateKotlin(type: Copy) {
     expand templateContext
 }
 
-sourceSets.main.kotlin.srcDir "$buildDir/generated/kotlin"
+sourceSets {
+    main.kotlin.srcDirs += "$buildDir/generated/kotlin"
+}
+
 compileKotlin.dependsOn generateKotlin
+licenseMain.dependsOn generateKotlin
+/*
+// Detekt creates its tasks after project evaluation (i.e. after evaluating this buildscript file) so that it can find
+// all of the relevant sources, so we need to add the dependency on generateKotlin *after* the evaluation phase.
+afterEvaluate {
+    tasks.getByName("detektMain").dependsOn generateKotlin
+}
+*/

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -29,64 +29,36 @@ application {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-common:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-jvm:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-scripting-jvm-host:$kotlinVersion"
+    implementation libs.bundles.kotlin.scripting
+    implementation libs.bundles.ktor.server
+    implementation libs.bundles.ktor.client
+    implementation libs.bundles.jackson
+    implementation libs.bundles.exposed
+    implementation libs.bundles.kotlinx.coroutines
+    implementation libs.bundles.koin
 
-    implementation "io.ktor:ktor-server-netty:$ktorVersion"
-    implementation "io.ktor:ktor-auth:$ktorVersion"
-    implementation "io.ktor:ktor-jackson:$ktorVersion"
-    implementation "io.ktor:ktor-locations:$ktorVersion"
-
-    implementation "io.ktor:ktor-client-apache:$ktorVersion"
-    implementation "io.ktor:ktor-client-auth-jvm:$ktorVersion"
-
-    implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
-
-    implementation (group: "ch.qos.logback", name: "logback-classic") {
-        version {
-            strictly "[$logbackVersion]"
-        }
-    }
-    implementation "org.jetbrains.exposed:exposed-core:$exposedVersion"
-    implementation "org.jetbrains.exposed:exposed-dao:$exposedVersion"
-    implementation "org.jetbrains.exposed:exposed-jdbc:$exposedVersion"
-    implementation "org.jetbrains.exposed:exposed-java-time:$exposedVersion"
-    implementation "org.xerial:sqlite-jdbc:$sqliteJdbcVersion"
-
-    implementation "com.xenomachina:kotlin-argparser:$argparserVersion"
-
-    implementation "com.discord4j:discord4j-core:$discord4JVersion"
-
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$coroutinesVersion"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-reactive:$coroutinesVersion"
-
-    implementation "io.insert-koin:koin-core:$koinVersion"
-    implementation "io.insert-koin:koin-logger-slf4j:$koinVersion"
-
-    implementation "io.lettuce:lettuce-core:$lettuceVersion"
-
-    implementation "guru.zoroark:ktor-rate-limit:$ktorRateLimitVersion"
-
-    implementation "org.bitbucket.b_c:jose4j:$jose4jVersion"
-
-    implementation "org.apache.commons:commons-dbcp2:$dbcp2Version"
+    implementation libs.kotlin.reflect
+    implementation libs.logback
+    implementation libs.sqlite
+    implementation libs.argparser
+    implementation libs.discord4j.core
+    implementation libs.lettuce.core
+    implementation libs.ktorRateLimit
+    implementation libs.jose4j
+    implementation libs.commonsDbcp2
 
     if (project.hasProperty("withFrontend"))
         runtimeOnly project(path: ":epilink-frontend", configuration: "frontendJarCfg")
 
-    testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-    testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion"
-    testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
-    testImplementation "io.mockk:mockk:$mockkVersion"
-    testImplementation "io.insert-koin:koin-test:$koinVersion"
-    testImplementation "io.ktor:ktor-server-test-host:$ktorVersion"
-    testImplementation "io.ktor:ktor-client-mock-jvm:$ktorVersion"
+    testImplementation libs.bundles.kotlin.test
 
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektVersion"
+    testImplementation libs.junit.jupiter
+    testImplementation libs.mockk
+    testImplementation libs.koin.test
+    testImplementation libs.ktor.server.testHost
+    testImplementation libs.ktor.client.mock.jvm
+    
+    detektPlugins libs.detekt.formatting
 }
 
 test {

--- a/bot/build.gradle
+++ b/bot/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     testImplementation libs.koin.test
     testImplementation libs.ktor.server.testHost
     testImplementation libs.ktor.client.mock.jvm
-    
+
     detektPlugins libs.detekt.formatting
 }
 
@@ -69,8 +69,6 @@ license {
     header rootProject.file("LHEADER")
     // Exclude front-end test files
     exclude("frontend/*")
-    // Generated file
-    exclude("org/epilink/bot/Version.kt")
 }
 
 // TODO Remove this when the default JaCoCo version is updated
@@ -80,7 +78,7 @@ jacoco {
 
 jacocoTestReport {
     reports {
-        xml.enabled true
+        xml.required = true
     }
 }
 

--- a/bot/src/main/kotlin/org/epilink/bot/Main.kt
+++ b/bot/src/main/kotlin/org/epilink/bot/Main.kt
@@ -104,7 +104,7 @@ fun main(args: Array<String>) = mainBody("epilink") {
         return@mainBody
     }
     logger.info(
-        "EpiLink version $VERSION, starting right up! See $DOCS for documentation. Report issues and " +
+        "EpiLink version $EPILINK_VERSION, starting right up! See $DOCS for documentation. Report issues and " +
                 "suggestions at $BUGS and join our Discord server for help."
     )
     if (cliArgs.verbose) {

--- a/bot/src/template/kotlin/org/epilink/bot/Version.kt
+++ b/bot/src/template/kotlin/org/epilink/bot/Version.kt
@@ -8,4 +8,4 @@
  */
 package org.epilink.bot
 
-internal const val VERSION: String = "${version}"
+const val EPILINK_VERSION: String = "${version}"

--- a/bot/src/template/kotlin/org/epilink/bot/Version.kt
+++ b/bot/src/template/kotlin/org/epilink/bot/Version.kt
@@ -1,3 +1,11 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * This Source Code Form is "Incompatible With Secondary Licenses", as
+ * defined by the Mozilla Public License, v. 2.0.
+ */
 package org.epilink.bot
 
 internal const val VERSION: String = "${version}"

--- a/bot/src/test/kotlin/org/epilink/bot/web/ApiUtils.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/web/ApiUtils.kt
@@ -14,7 +14,6 @@ import io.ktor.sessions.defaultSessionSerializer
 import io.ktor.sessions.get
 import io.ktor.sessions.sessions
 import io.ktor.util.AttributeKey
-import io.ktor.util.KtorExperimentalAPI
 import io.ktor.util.pipeline.PipelineContext
 import io.mockk.CapturingSlot
 import io.mockk.coEvery
@@ -105,7 +104,6 @@ internal class UnsafeTestSessionStorage : SimplifiedSessionStorage() {
 }
 
 @OptIn(
-    KtorExperimentalAPI::class, // We get a choice between a deprecated or an experimental func...
     UsesTrueIdentity::class // for setting up identity mocks
 )
 internal fun KoinTest.setupSession(

--- a/bot/src/test/kotlin/org/epilink/bot/web/DiscordBackEndTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/web/DiscordBackEndTest.kt
@@ -13,7 +13,6 @@ import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondError
 import io.ktor.client.engine.mock.toByteArray
 import io.ktor.http.*
-import io.ktor.util.KtorExperimentalAPI
 import org.epilink.bot.EndpointException
 import org.epilink.bot.KoinBaseTest
 import org.epilink.bot.StandardErrorCodes
@@ -30,7 +29,7 @@ class DiscordBackEndTest : KoinBaseTest<DiscordBackEnd>(
     }
 ) {
     @Test
-    fun `Test Discord auth stub`() = test {
+    fun `Test Discord auth stub`(): Unit = test {
         getAuthorizeStub().apply {
             assertTrue(contains("client_id=DiscordClientId"), "Expected a client ID")
             assertTrue(contains("scope=identify"), "Expected the scope to be set to identify")
@@ -46,7 +45,6 @@ class DiscordBackEndTest : KoinBaseTest<DiscordBackEnd>(
         declareClientHandler(onlyMatchUrl = "https://discord.com/api/v6/oauth2/token") { request ->
             assertEquals(HttpMethod.Post, request.method)
             assertEquals(ContentType.Application.FormUrlEncoded, request.body.contentType)
-            @OptIn(KtorExperimentalAPI::class)
             val params = String(request.body.toByteArray()).parseUrlEncodedParameters()
             assertEquals("DiscordClientId", params["client_id"])
             assertEquals("DiscordSecret", params["client_secret"])

--- a/bot/src/test/kotlin/org/epilink/bot/web/MetaTest.kt
+++ b/bot/src/test/kotlin/org/epilink/bot/web/MetaTest.kt
@@ -11,6 +11,7 @@ package org.epilink.bot.web
 import io.ktor.http.ContentType
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.HttpStatusCode.Companion.NotFound
 import io.ktor.http.HttpStatusCode.Companion.OK
 import io.ktor.routing.routing
 import io.ktor.server.testing.TestApplicationEngine
@@ -205,7 +206,7 @@ class MetaTest : KoinBaseTest<Unit>(
         withTestEpiLink {
             for (urlFragment in assetEndpoints) {
                 val call = handleRequest(HttpMethod.Get, "/api/v1/meta/$urlFragment")
-                assertFalse(call.requestHandled)
+                call.assertStatus(NotFound)
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,22 +10,3 @@ swaggerUiVersion = 3.51.1
 
 # Multi-purpose versions
 kotlinVersion = 1.5.21
-
-# Back-end dependencies versions
-argparserVersion = 2.0.7
-coroutinesVersion = 1.5.1
-dbcp2Version = 2.8.0
-discord4JVersion = 3.1.7
-exposedVersion = 0.32.1
-jacksonVersion = 2.12.4
-jose4jVersion = 0.7.8
-koinVersion = 2.2.3
-ktorRateLimitVersion = 0.0.1
-ktorVersion = 1.6.2
-lettuceVersion = 6.1.4.RELEASE
-logbackVersion = 1.2.3-litarvan
-sqliteJdbcVersion = 3.36.0.1
-
-# Back-end test dependencies versions
-junitVersion = 5.7.2
-mockkVersion = 1.12.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,8 @@
 # Gradle plugin versions
+# Non-plugin versions are available in gradle/libs.versions.toml
 licenseVersion = 0.16.1
 nodeVersion = 3.1.0
 swaggerGeneratorVersion = 2.18.2
 versionsVersion = 0.39.0
 detektVersion = 1.18.0-RC3
-
-# Swagger dependency version
-swaggerUiVersion = 3.51.1
-
-# Multi-purpose versions
 kotlinVersion = 1.5.21

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,95 @@
+[versions]
+kotlin = "1.5.21"
+jackson = "2.12.4"
+argparser = "2.0.7"
+coroutines = "1.5.1"
+dbcp2 = "2.8.0"
+discord4J = "3.1.7"
+exposed = "0.32.1"
+jose4j = "0.7.8"
+koin = "2.2.3"
+ktorRateLimit = "0.0.1"
+ktor = "1.6.2"
+lettuce = "6.1.4.RELEASE"
+logback = { strictly = "1.2.3-litarvan" }
+sqliteJdbc = "3.36.0.1"
+junit = "5.7.2"
+mockk = "1.12.0"
+detekt = "1.18.0-RC3"
+
+[libraries]
+
+# MAIN CODE LIBRARIES
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+
+kotlin-scripting-common = { module = "org.jetbrains.kotlin:kotlin-scripting-common", version.ref = "kotlin" }
+kotlin-scripting-jvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin" }
+kotlin-scripting-jvmHost = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm-host", version.ref = "kotlin" }
+
+ktor-server-netty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
+ktor-server-auth = { module = "io.ktor:ktor-auth", version.ref = "ktor" }
+ktor-server-jackson = { module = "io.ktor:ktor-jackson", version.ref = "ktor" }
+ktor-server-locations = { module = "io.ktor:ktor-locations", version.ref = "ktor" }
+
+ktor-client-apache = { module = "io.ktor:ktor-client-apache", version.ref = "ktor" }
+ktor-client-auth-jvm = { module = "io.ktor:ktor-client-auth-jvm", version.ref = "ktor" }
+
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
+jackson-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+
+logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+
+exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
+exposed-dao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
+exposed-jdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }
+exposed-javaTime = { module = "org.jetbrains.exposed:exposed-java-time", version.ref = "exposed" }
+
+sqlite = { module = "org.xerial:sqlite-jdbc", version.ref = "sqliteJdbc" }
+
+argparser = { module = "com.xenomachina:kotlin-argparser", version.ref = "argparser" }
+
+discord4j-core = { module = "com.discord4j:discord4j-core", version.ref = "discord4J" }
+
+kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "coroutines" }
+kotlinx-coroutines-reactive = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactive", version.ref = "coroutines" }
+
+koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
+koin-logger-slf4j = { module = "io.insert-koin:koin-logger-slf4j", version.ref = "koin" }
+
+lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
+
+ktorRateLimit = { module = "guru.zoroark:ktor-rate-limit", version.ref = "ktorRateLimit"}
+
+jose4j = { module = "org.bitbucket.b_c:jose4j", version.ref = "jose4j" }
+
+commonsDbcp2 = { module = "org.apache.commons:commons-dbcp2", version.ref = "dbcp2" }
+
+# TEST CODE LIBRARIES
+
+kotlin-test-core = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
+
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+
+koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
+
+ktor-server-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
+ktor-client-mock-jvm = { module = "io.ktor:ktor-client-mock-jvm", version.ref = "ktor" }
+
+# DETEKT PLUGINS
+
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+[bundles]
+
+kotlin-scripting = ["kotlin-scripting-common", "kotlin-scripting-jvm", "kotlin-scripting-jvmHost"]
+ktor-server = ["ktor-server-netty", "ktor-server-auth", "ktor-server-jackson", "ktor-server-locations"]
+ktor-client = ["ktor-client-apache", "ktor-client-auth-jvm"]
+jackson = ["jackson-databind", "jackson-kotlin", "jackson-yaml"]
+exposed = ["exposed-core", "exposed-dao", "exposed-jdbc", "exposed-javaTime"]
+kotlinx-coroutines = ["kotlinx-coroutines-reactor", "kotlinx-coroutines-reactive"]
+koin = ["koin-core", "koin-logger-slf4j"]
+kotlin-test = ["kotlin-test-core", "kotlin-test-junit5"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ sqliteJdbc = "3.36.0.1"
 junit = "5.7.2"
 mockk = "1.12.0"
 detekt = "1.18.0-RC3"
+swaggerUi = "3.51.1"
 
 [libraries]
 
@@ -82,6 +83,10 @@ ktor-client-mock-jvm = { module = "io.ktor:ktor-client-mock-jvm", version.ref = 
 # DETEKT PLUGINS
 
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+
+# SWAGGER UI DEPENDENCY
+
+swaggerUi = { module = "org.webjars:swagger-ui", version.ref = "swaggerUi"}
 
 [bundles]
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
+enableFeaturePreview("VERSION_CATALOGS")
 rootProject.name = 'EpiLink'
 include 'bot', 'web', 'swagger'
 project(":bot").name = "epilink-backend"

--- a/swagger/build.gradle
+++ b/swagger/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {
-    swaggerUI "org.webjars:swagger-ui:$swaggerUiVersion"
+    swaggerUI libs.swaggerUi
 }
 
 swaggerSources {


### PR DESCRIPTION
<!-- Describe your pull request here -->
### Description

This PR:

- Changes our current properties-based solution for managing dependency versions to the new (incubating) [version catalog feature from Gradle](https://docs.gradle.org/current/userguide/platforms.html#sub:central-declaration-of-dependencies). This is an experimental feature, but rolling back these changes is quite easy, so I'm willing to go all in.
- Adds the -Werror flag on Kotlin compilation to report all errors as warnings: multiple deprecation warnings went under the radar because of this, and this fixes some of the bullet points in #293 
- Fixes deprecation warnings emitted by Gradle

<!-- Delete the following section if this PR does not address any issue -->
#### Related issue(s)

* Fixes #300: this is the maximal warning setting for Kotlin, and this is also covered by the previous addition of Detekt
* Fixes #301: Warnings **cannot** fly under the radar as they would fail compilation on the CI
* Fixes #302: -Werror effectively does this.

<!-- Replace the [ ] by [X] to tick boxes -->
<!-- Remove any item which does not apply to this PR -->
### TODO

* [N/A] Notify the team of GDPR-related changes
* [N/A] Update the docs with the changes that have been made
* [ ] Update `CHANGELOG.md`
